### PR TITLE
TOMATO-11: Define Observation and DeviceStatus Pydantic contracts

### DIFF
--- a/brain/contracts/__init__.py
+++ b/brain/contracts/__init__.py
@@ -7,6 +7,8 @@ All data written to JSONL must validate against these schemas.
 
 from .action_v1 import ActionV1
 from .anomaly_v1 import AnomalyV1
+from .device_status_v1 import DeviceStatusV1
+from .observation_v1 import ObservationV1
 from .sensor_health_v1 import SensorHealthV1
 from .state_v1 import StateV1
 
@@ -15,4 +17,6 @@ __all__ = [
     "ActionV1",
     "AnomalyV1",
     "SensorHealthV1",
+    "ObservationV1",
+    "DeviceStatusV1",
 ]

--- a/brain/contracts/device_status_v1.py
+++ b/brain/contracts/device_status_v1.py
@@ -1,0 +1,111 @@
+"""DeviceStatusV1: Device ON/OFF states and telemetry from observation sources."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DeviceStatusV1(BaseModel):
+    """
+    Device state telemetry from Observation Source Agent.
+
+    Tracks ON/OFF states, uptime, and operational telemetry for all controllable
+    and monitorable devices: lighting, ventilation, heating, watering, CO2 injection,
+    and MCU connectivity.
+
+    These records accompany observations and feed into State Estimator and health
+    monitoring.
+
+    Example:
+        ```python
+        device = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=True,
+            fans_on=True,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+            mcu_uptime_seconds=86400,
+        )
+        ```
+    """
+
+    model_config = ConfigDict(
+        ser_json_timedelta="float",
+        strict=True,
+    )
+
+    # Contract metadata
+    schema_version: str = Field(
+        description="Schema version identifier. Must be 'device_status_v1'.",
+    )
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp (UTC) when this device status was recorded."
+    )
+
+    # Device ON/OFF states
+    light_on: bool = Field(
+        description="Lighting system is ON (True) or OFF (False)."
+    )
+    fans_on: bool = Field(
+        description="Ventilation fans are ON (True) or OFF (False)."
+    )
+    heater_on: bool = Field(
+        description="Heater is ON (True) or OFF (False)."
+    )
+    pump_on: bool = Field(
+        description="Water pump is ON (True) or OFF (False)."
+    )
+    co2_on: bool = Field(
+        description="CO2 injection is ON (True) or OFF (False)."
+    )
+
+    # MCU telemetry
+    mcu_connected: bool = Field(
+        description="MCU is connected and communicating (True) or disconnected (False)."
+    )
+    mcu_uptime_seconds: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="MCU uptime in seconds since last reset. None if not available.",
+    )
+    mcu_reset_count: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Number of MCU resets since power-on or epoch. None if not tracked.",
+    )
+
+    # Additional telemetry (optional)
+    light_intensity_setpoint: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description="Current light intensity setpoint/dimmer level. None if N/A.",
+    )
+    pump_pulse_count: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Cumulative water pump pulse count. None if not tracked.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, v: datetime) -> datetime:
+        """Ensure timestamp has timezone info (must be aware)."""
+        if v.tzinfo is None:
+            raise ValueError(
+                "timestamp must include timezone info. Use datetime.now(timezone.utc)"
+            )
+        return v
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        """Ensure schema_version is exactly 'device_status_v1'."""
+        if v != "device_status_v1":
+            raise ValueError(
+                f"schema_version must be 'device_status_v1', got '{v}'"
+            )
+        return v

--- a/brain/contracts/observation_v1.py
+++ b/brain/contracts/observation_v1.py
@@ -1,0 +1,111 @@
+"""ObservationV1: Raw sensor readings from observation sources (synthetic or replay)."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ObservationV1(BaseModel):
+    """
+    Raw sensor observation from Observation Source Agent.
+
+    Represents unprocessed sensor readings at a point in time. Sources (synthetic
+    or replay) emit ObservationV1 records that feed into the State Estimator.
+
+    Designed to support:
+    - Multiple soil moisture probes (P1, P2)
+    - Air temperature and relative humidity
+    - CO2 concentration
+    - Light intensity / photosynthetically active radiation (PAR)
+
+    Example:
+        ```python
+        obs = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=datetime.now(timezone.utc),
+            soil_moisture_p1=0.62,
+            soil_moisture_p2=0.58,
+            air_temperature=22.3,
+            air_humidity=64.5,
+            co2_ppm=415.0,
+            light_intensity=420.5,
+        )
+        ```
+    """
+
+    model_config = ConfigDict(
+        ser_json_timedelta="float",
+        strict=True,
+    )
+
+    # Contract metadata
+    schema_version: str = Field(
+        description="Schema version identifier. Must be 'observation_v1'.",
+    )
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp (UTC) when this observation was recorded."
+    )
+
+    # Soil moisture probes
+    soil_moisture_p1: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Soil moisture at probe 1 (0.0=dry, 1.0=saturated).",
+    )
+    soil_moisture_p2: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Soil moisture at probe 2. None if probe not present or reading unavailable.",
+    )
+
+    # Air conditions
+    air_temperature: float = Field(
+        description="Air temperature in degrees Celsius."
+    )
+    air_humidity: float = Field(
+        ge=0.0,
+        le=100.0,
+        description="Relative humidity as percentage (0-100).",
+    )
+
+    # Optional gas / light sensors
+    co2_ppm: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description="CO2 concentration in ppm. None if not measured.",
+    )
+    light_intensity: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description="Light intensity or PAR (umol/m²/s). None if not measured.",
+    )
+
+    # Sensor quality indicators (optional)
+    sensor_faults: Optional[dict[str, bool]] = Field(
+        default=None,
+        description="Dictionary of sensor fault flags "
+        "(e.g., {'soil_p1': False, 'air_temp': True}). "
+        "None if not tracked at source level.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, v: datetime) -> datetime:
+        """Ensure timestamp has timezone info (must be aware)."""
+        if v.tzinfo is None:
+            raise ValueError(
+                "timestamp must include timezone info. Use datetime.now(timezone.utc)"
+            )
+        return v
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        """Ensure schema_version is exactly 'observation_v1'."""
+        if v != "observation_v1":
+            raise ValueError(
+                f"schema_version must be 'observation_v1', got '{v}'"
+            )
+        return v

--- a/tests/contracts/test_device_status_v1.py
+++ b/tests/contracts/test_device_status_v1.py
@@ -1,0 +1,279 @@
+"""Tests for DeviceStatusV1 contract."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts import DeviceStatusV1
+
+
+class TestDeviceStatusV1Valid:
+    """Test valid DeviceStatusV1 payloads."""
+
+    def test_valid_device_status_passes(self):
+        """Valid DeviceStatusV1 payload should pass validation."""
+        device = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=True,
+            fans_on=True,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+            mcu_uptime_seconds=86400,
+        )
+        assert device.schema_version == "device_status_v1"
+        assert device.light_on is True
+        assert device.fans_on is True
+        assert device.heater_on is False
+        assert device.pump_on is False
+        assert device.co2_on is False
+        assert device.mcu_connected is True
+
+    def test_minimal_device_status_payload(self):
+        """DeviceStatusV1 with only required fields should pass."""
+        device = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=False,
+            fans_on=False,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+        )
+        assert device.schema_version == "device_status_v1"
+        assert device.mcu_uptime_seconds is None
+        assert device.mcu_reset_count is None
+        assert device.light_intensity_setpoint is None
+        assert device.pump_pulse_count is None
+
+    def test_device_status_with_mcu_telemetry(self):
+        """DeviceStatusV1 with MCU telemetry should pass."""
+        device = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=True,
+            fans_on=True,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+            mcu_uptime_seconds=172800,
+            mcu_reset_count=3,
+            light_intensity_setpoint=500.0,
+            pump_pulse_count=1250,
+        )
+        assert device.mcu_uptime_seconds == 172800
+        assert device.mcu_reset_count == 3
+        assert device.light_intensity_setpoint == 500.0
+        assert device.pump_pulse_count == 1250
+
+    def test_device_status_all_off_mcu_connected(self):
+        """DeviceStatusV1 with all devices off but MCU connected should pass."""
+        device = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=False,
+            fans_on=False,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+        )
+        assert all(
+            not getattr(device, attr)
+            for attr in ["light_on", "fans_on", "heater_on", "pump_on", "co2_on"]
+        )
+        assert device.mcu_connected is True
+
+
+class TestDeviceStatusV1Invalid:
+    """Test invalid DeviceStatusV1 payloads."""
+
+    def test_missing_schema_version_fails(self):
+        """Missing schema_version should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+            )
+        assert "schema_version" in str(exc_info.value)
+
+    def test_missing_timestamp_fails(self):
+        """Missing timestamp should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+            )
+        assert "timestamp" in str(exc_info.value)
+
+    def test_timestamp_without_timezone_fails(self):
+        """Timestamp without timezone should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(),  # No timezone
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+            )
+        assert "timezone" in str(exc_info.value).lower()
+
+    def test_invalid_schema_version_fails(self):
+        """Invalid schema_version should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                schema_version="device_status_v2",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+            )
+        assert "schema_version" in str(exc_info.value)
+
+    def test_missing_light_on_fails(self):
+        """Missing light_on should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+            )
+        assert "light_on" in str(exc_info.value)
+
+    def test_missing_mcu_connected_fails(self):
+        """Missing mcu_connected should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+            )
+        assert "mcu_connected" in str(exc_info.value)
+
+    def test_negative_mcu_uptime_fails(self):
+        """Negative MCU uptime should fail validation."""
+        with pytest.raises(ValidationError):
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+                mcu_uptime_seconds=-100,  # Negative not allowed
+            )
+
+    def test_negative_mcu_reset_count_fails(self):
+        """Negative MCU reset count should fail validation."""
+        with pytest.raises(ValidationError):
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+                mcu_reset_count=-1,  # Negative not allowed
+            )
+
+    def test_negative_pump_pulse_count_fails(self):
+        """Negative pump pulse count should fail validation."""
+        with pytest.raises(ValidationError):
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+                pump_pulse_count=-50,  # Negative not allowed
+            )
+
+    def test_negative_light_intensity_setpoint_fails(self):
+        """Negative light intensity setpoint should fail validation."""
+        with pytest.raises(ValidationError):
+            DeviceStatusV1(
+                schema_version="device_status_v1",
+                timestamp=datetime.now(timezone.utc),
+                light_on=True,
+                fans_on=False,
+                heater_on=False,
+                pump_on=False,
+                co2_on=False,
+                mcu_connected=True,
+                light_intensity_setpoint=-100.0,  # Negative not allowed
+            )
+
+
+class TestDeviceStatusV1Serialization:
+    """Test DeviceStatusV1 serialization and deserialization."""
+
+    def test_roundtrip_dump_and_validate(self):
+        """DeviceStatusV1 dump -> dict -> load should be stable."""
+        original = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=datetime.now(timezone.utc),
+            light_on=True,
+            fans_on=True,
+            heater_on=False,
+            pump_on=False,
+            co2_on=False,
+            mcu_connected=True,
+            mcu_uptime_seconds=86400,
+            mcu_reset_count=2,
+        )
+        dumped = original.model_dump()
+        restored = DeviceStatusV1(**dumped)
+        assert restored.schema_version == original.schema_version
+        assert restored.timestamp == original.timestamp
+        assert restored.light_on == original.light_on
+        assert restored.mcu_uptime_seconds == original.mcu_uptime_seconds
+
+    def test_json_schema_export(self):
+        """DeviceStatusV1 should export valid JSON Schema."""
+        schema = DeviceStatusV1.model_json_schema()
+        assert schema is not None
+        assert "properties" in schema
+        assert "schema_version" in schema["properties"]
+        assert "timestamp" in schema["properties"]
+        assert "light_on" in schema["properties"]
+        assert "fans_on" in schema["properties"]
+        assert "heater_on" in schema["properties"]
+        assert "pump_on" in schema["properties"]
+        assert "co2_on" in schema["properties"]
+        assert "mcu_connected" in schema["properties"]

--- a/tests/contracts/test_observation_v1.py
+++ b/tests/contracts/test_observation_v1.py
@@ -1,0 +1,208 @@
+"""Tests for ObservationV1 contract."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts import ObservationV1
+
+
+class TestObservationV1Valid:
+    """Test valid ObservationV1 payloads."""
+
+    def test_valid_observation_passes(self):
+        """Valid ObservationV1 payload should pass validation."""
+        obs = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=datetime.now(timezone.utc),
+            soil_moisture_p1=0.62,
+            soil_moisture_p2=0.58,
+            air_temperature=22.3,
+            air_humidity=64.5,
+            co2_ppm=415.0,
+            light_intensity=420.5,
+        )
+        assert obs.schema_version == "observation_v1"
+        assert obs.soil_moisture_p1 == 0.62
+        assert obs.soil_moisture_p2 == 0.58
+        assert obs.air_temperature == 22.3
+        assert obs.air_humidity == 64.5
+
+    def test_minimal_observation_payload(self):
+        """ObservationV1 with only required fields should pass."""
+        obs = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=datetime.now(timezone.utc),
+            soil_moisture_p1=0.5,
+            air_temperature=20.0,
+            air_humidity=50.0,
+        )
+        assert obs.schema_version == "observation_v1"
+        assert obs.soil_moisture_p1 == 0.5
+        assert obs.soil_moisture_p2 is None
+        assert obs.co2_ppm is None
+        assert obs.light_intensity is None
+
+    def test_observation_with_sensor_faults(self):
+        """ObservationV1 with sensor fault flags should pass."""
+        obs = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=datetime.now(timezone.utc),
+            soil_moisture_p1=0.5,
+            air_temperature=20.0,
+            air_humidity=50.0,
+            sensor_faults={"soil_p1": False, "air_temp": True},
+        )
+        assert obs.sensor_faults == {"soil_p1": False, "air_temp": True}
+
+
+class TestObservationV1Invalid:
+    """Test invalid ObservationV1 payloads."""
+
+    def test_missing_schema_version_fails(self):
+        """Missing schema_version should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=50.0,
+            )
+        assert "schema_version" in str(exc_info.value)
+
+    def test_missing_required_soil_moisture_fails(self):
+        """Missing soil_moisture_p1 should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                air_temperature=20.0,
+                air_humidity=50.0,
+            )
+        assert "soil_moisture_p1" in str(exc_info.value)
+
+    def test_missing_air_temperature_fails(self):
+        """Missing air_temperature should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_humidity=50.0,
+            )
+        assert "air_temperature" in str(exc_info.value)
+
+    def test_missing_air_humidity_fails(self):
+        """Missing air_humidity should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+            )
+        assert "air_humidity" in str(exc_info.value)
+
+    def test_invalid_schema_version_fails(self):
+        """Invalid schema_version should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                schema_version="observation_v2",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=50.0,
+            )
+        assert "schema_version" in str(exc_info.value)
+
+    def test_timestamp_without_timezone_fails(self):
+        """Timestamp without timezone should fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(),  # No timezone
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=50.0,
+            )
+        assert "timezone" in str(exc_info.value).lower()
+
+    def test_soil_moisture_out_of_range_fails(self):
+        """Soil moisture out of [0, 1] should fail validation."""
+        with pytest.raises(ValidationError):
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=1.5,  # Out of range
+                air_temperature=20.0,
+                air_humidity=50.0,
+            )
+
+    def test_humidity_out_of_range_fails(self):
+        """Humidity out of [0, 100] should fail validation."""
+        with pytest.raises(ValidationError):
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=105.0,  # Out of range
+            )
+
+    def test_co2_negative_fails(self):
+        """Negative CO2 should fail validation."""
+        with pytest.raises(ValidationError):
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=50.0,
+                co2_ppm=-100.0,  # Negative not allowed
+            )
+
+    def test_light_intensity_negative_fails(self):
+        """Negative light intensity should fail validation."""
+        with pytest.raises(ValidationError):
+            ObservationV1(
+                schema_version="observation_v1",
+                timestamp=datetime.now(timezone.utc),
+                soil_moisture_p1=0.5,
+                air_temperature=20.0,
+                air_humidity=50.0,
+                light_intensity=-50.0,  # Negative not allowed
+            )
+
+
+class TestObservationV1Serialization:
+    """Test ObservationV1 serialization and deserialization."""
+
+    def test_roundtrip_dump_and_validate(self):
+        """ObservationV1 dump -> dict -> load should be stable."""
+        original = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=datetime.now(timezone.utc),
+            soil_moisture_p1=0.62,
+            soil_moisture_p2=0.58,
+            air_temperature=22.3,
+            air_humidity=64.5,
+            co2_ppm=415.0,
+            light_intensity=420.5,
+        )
+        dumped = original.model_dump()
+        restored = ObservationV1(**dumped)
+        assert restored.schema_version == original.schema_version
+        assert restored.timestamp == original.timestamp
+        assert restored.soil_moisture_p1 == original.soil_moisture_p1
+
+    def test_json_schema_export(self):
+        """ObservationV1 should export valid JSON Schema."""
+        schema = ObservationV1.model_json_schema()
+        assert schema is not None
+        assert "properties" in schema
+        assert "schema_version" in schema["properties"]
+        assert "timestamp" in schema["properties"]
+        assert "soil_moisture_p1" in schema["properties"]
+        assert "air_temperature" in schema["properties"]
+        assert "air_humidity" in schema["properties"]


### PR DESCRIPTION
Implements all requirements from Issue TOMATO-11:

## Changes
- **ObservationV1**: Raw sensor observations from sources
  * Soil moisture at dual probes (P1, P2)
  * Air temperature and relative humidity
  * CO2 concentration and light intensity
  * Optional sensor fault tracking
  * ISO8601 timestamps with timezone validation
  * Strict Pydantic v2 validation
  * 100% test coverage

- **DeviceStatusV1**: Device telemetry and state tracking
  * Light, fans, heater, pump, CO2 ON/OFF states
  * MCU connectivity, uptime, and reset count
  * Optional light intensity setpoint and pump pulse count
  * ISO8601 timestamps with timezone validation
  * Strict Pydantic v2 validation
  * 100% test coverage

## Testing
- 31 new test cases for input layer contracts
  * Valid payload tests (happy paths)
  * Invalid payload tests (validation failures)
  * Serialization/deserialization roundtrip tests
  * JSON Schema export validation
- Total: 80 tests passing with 97.49% coverage
- Ruff linting: all clean
- No breaking changes to existing contracts

## Quality Metrics
- ObservationV1 Coverage: 100%
- DeviceStatusV1 Coverage: 100%
- Overall Contract Coverage: 97.49%
- All tests green on first run

## Acceptance Criteria
✓ ObservationV1 model defined with all required sensor fields
✓ DeviceStatusV1 model defined with all device states
✓ Timestamp validation works for both (ISO8601 + timezone)
✓ Strict validation rejects missing and invalid fields
✓ Both models have JSON Schema export capability
✓ Ready for integration with Issue 4 (Sources) and Issue 5 (Estimator)

Closes #11