### PR TITLE
TOMATO-14: add observation source interface with synthetic/replay backends

### DIFF
--- a/brain/sources/__init__.py
+++ b/brain/sources/__init__.py
@@ -1,0 +1,13 @@
+"""Observation source interfaces and implementations."""
+
+from .interface import ObservationSource, iter_observations
+from .replay_source import ReplaySource
+from .synthetic_source import SyntheticConfig, SyntheticSource
+
+__all__ = [
+    "ObservationSource",
+    "ReplaySource",
+    "SyntheticConfig",
+    "SyntheticSource",
+    "iter_observations",
+]

--- a/brain/sources/interface.py
+++ b/brain/sources/interface.py
@@ -1,0 +1,34 @@
+"""Observation source interface for synthetic and replay backends."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Protocol
+
+from brain.contracts import DeviceStatusV1, ObservationV1
+
+
+class ObservationSource(Protocol):
+    """Unified source interface for observation streams.
+
+    Implementations must:
+    - Emit ordered observations
+    - Be deterministic for fixed inputs (e.g., seed or static file)
+    - Return None at end-of-stream
+    """
+
+    def next_observation(
+        self,
+    ) -> tuple[ObservationV1, DeviceStatusV1] | None:
+        """Return the next observation and device status, or None at EOF."""
+
+
+def iter_observations(
+    source: ObservationSource,
+) -> Generator[tuple[ObservationV1, DeviceStatusV1], None, None]:
+    """Yield observations until the source is exhausted."""
+    while True:
+        item = source.next_observation()
+        if item is None:
+            return
+        yield item

--- a/brain/sources/replay_source.py
+++ b/brain/sources/replay_source.py
@@ -1,0 +1,90 @@
+"""Replay observation source from JSONL files."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Optional, TextIO
+
+from brain.contracts import DeviceStatusV1, ObservationV1
+
+logger = logging.getLogger(__name__)
+
+
+class ReplaySource:
+    """Replay ObservationV1 + DeviceStatusV1 records from JSONL.
+
+    Each JSONL line must be a JSON object with keys:
+    - "observation": dict matching ObservationV1
+    - "device_status": dict matching DeviceStatusV1
+    """
+
+    def __init__(
+        self,
+        path: str,
+        malformed_policy: Literal["skip", "fail_fast"] = "skip",
+    ) -> None:
+        if malformed_policy not in {"skip", "fail_fast"}:
+            raise ValueError(
+                "malformed_policy must be 'skip' or 'fail_fast'"
+            )
+        self._path = Path(path)
+        self._policy = malformed_policy
+        self._handle: Optional[TextIO] = None
+        self._line_no = 0
+
+    def _ensure_open(self) -> None:
+        if self._handle is None:
+            self._handle = self._path.open("r", encoding="utf-8")
+
+    @staticmethod
+    def _parse_timestamp(value):
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        return value
+
+    def next_observation(
+        self,
+    ) -> tuple[ObservationV1, DeviceStatusV1] | None:
+        self._ensure_open()
+        assert self._handle is not None
+        while True:
+            line = self._handle.readline()
+            if line == "":
+                return None
+            self._line_no += 1
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+                observation_payload = payload["observation"]
+                device_payload = payload["device_status"]
+                if "timestamp" in observation_payload:
+                    observation_payload["timestamp"] = self._parse_timestamp(
+                        observation_payload["timestamp"]
+                    )
+                if "timestamp" in device_payload:
+                    device_payload["timestamp"] = self._parse_timestamp(
+                        device_payload["timestamp"]
+                    )
+                observation = ObservationV1(**observation_payload)
+                device_status = DeviceStatusV1(**device_payload)
+                return observation, device_status
+            except Exception as exc:  # noqa: BLE001
+                if self._policy == "fail_fast":
+                    raise ValueError(
+                        f"Malformed JSONL at line {self._line_no}"
+                    ) from exc
+                logger.warning(
+                    "Malformed JSONL at line %s: %s",
+                    self._line_no,
+                    exc,
+                )
+                continue

--- a/brain/sources/synthetic_source.py
+++ b/brain/sources/synthetic_source.py
@@ -1,0 +1,159 @@
+"""Synthetic observation source with noise, diurnal cycle, and scenarios."""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from brain.contracts import DeviceStatusV1, ObservationV1
+
+ScenarioHook = Callable[
+    [ObservationV1, DeviceStatusV1, random.Random, int],
+    tuple[ObservationV1, DeviceStatusV1],
+]
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value
+
+
+@dataclass
+class SyntheticConfig:
+    """Configuration for SyntheticSource generation."""
+
+    seed: Optional[int] = None
+    start_time: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    step_seconds: int = 600
+    count: Optional[int] = None
+
+    # Base means
+    base_air_temperature: float = 22.0
+    base_air_humidity: float = 60.0
+    base_soil_moisture_p1: float = 0.55
+    base_soil_moisture_p2: float = 0.52
+    base_co2_ppm: float = 420.0
+    base_light_intensity: float = 500.0
+
+    # Noise amplitudes (std-like scale)
+    noise_air_temperature: float = 0.4
+    noise_air_humidity: float = 2.0
+    noise_soil_moisture: float = 0.01
+    noise_co2_ppm: float = 10.0
+    noise_light_intensity: float = 15.0
+
+    # Diurnal cycle (sinusoidal) configuration
+    diurnal_temp_amp: float = 3.0
+    diurnal_humidity_amp: float = -6.0
+    diurnal_light_amp: float = 1.0
+    diurnal_phase_hours: float = 6.0  # peak around noon
+
+    scenarios: list[ScenarioHook] = field(default_factory=list)
+
+
+class SyntheticSource:
+    """Generate synthetic observations with noise and diurnal cycles."""
+
+    def __init__(self, config: SyntheticConfig) -> None:
+        if config.start_time.tzinfo is None:
+            raise ValueError("start_time must be timezone-aware")
+        if config.step_seconds <= 0:
+            raise ValueError("step_seconds must be positive")
+        if config.count is not None and config.count < 0:
+            raise ValueError("count must be non-negative or None")
+        self._config = config
+        self._rng = random.Random(config.seed)
+        self._index = 0
+        self._current_time = config.start_time
+
+    def next_observation(
+        self,
+    ) -> tuple[ObservationV1, DeviceStatusV1] | None:
+        if self._config.count is not None and self._index >= self._config.count:
+            return None
+
+        hour_fraction = (
+            self._current_time.hour
+            + self._current_time.minute / 60.0
+            + self._current_time.second / 3600.0
+        )
+        angle = 2.0 * math.pi * (
+            (hour_fraction - self._config.diurnal_phase_hours) / 24.0
+        )
+        diurnal = math.sin(angle)
+
+        temp = (
+            self._config.base_air_temperature
+            + self._config.diurnal_temp_amp * diurnal
+            + self._rng.gauss(0.0, self._config.noise_air_temperature)
+        )
+        humidity = (
+            self._config.base_air_humidity
+            + self._config.diurnal_humidity_amp * diurnal
+            + self._rng.gauss(0.0, self._config.noise_air_humidity)
+        )
+        soil_p1 = (
+            self._config.base_soil_moisture_p1
+            + self._rng.gauss(0.0, self._config.noise_soil_moisture)
+        )
+        soil_p2 = (
+            self._config.base_soil_moisture_p2
+            + self._rng.gauss(0.0, self._config.noise_soil_moisture)
+        )
+        co2 = (
+            self._config.base_co2_ppm
+            + self._rng.gauss(0.0, self._config.noise_co2_ppm)
+        )
+
+        light_day_factor = max(0.0, diurnal) * self._config.diurnal_light_amp
+        light = (
+            self._config.base_light_intensity * light_day_factor
+            + self._rng.gauss(0.0, self._config.noise_light_intensity)
+        )
+
+        observation = ObservationV1(
+            schema_version="observation_v1",
+            timestamp=self._current_time,
+            soil_moisture_p1=_clamp(soil_p1, 0.0, 1.0),
+            soil_moisture_p2=_clamp(soil_p2, 0.0, 1.0),
+            air_temperature=temp,
+            air_humidity=_clamp(humidity, 0.0, 100.0),
+            co2_ppm=max(0.0, co2),
+            light_intensity=max(0.0, light),
+        )
+
+        device_status = DeviceStatusV1(
+            schema_version="device_status_v1",
+            timestamp=self._current_time,
+            light_on=observation.light_intensity is not None
+            and observation.light_intensity > 0.0,
+            fans_on=observation.air_temperature >= 26.0,
+            heater_on=observation.air_temperature <= 18.0,
+            pump_on=False,
+            co2_on=observation.co2_ppm is not None
+            and observation.co2_ppm < 380.0,
+            mcu_connected=True,
+            mcu_uptime_seconds=self._index * self._config.step_seconds,
+            mcu_reset_count=0,
+            light_intensity_setpoint=observation.light_intensity,
+            pump_pulse_count=0,
+        )
+
+        for hook in self._config.scenarios:
+            observation, device_status = hook(
+                observation, device_status, self._rng, self._index
+            )
+
+        self._index += 1
+        self._current_time = self._current_time + timedelta(
+            seconds=self._config.step_seconds
+        )
+        return observation, device_status

--- a/tests/sources/test_interface.py
+++ b/tests/sources/test_interface.py
@@ -1,0 +1,56 @@
+"""Tests for observation source interface compliance."""
+
+from datetime import datetime, timezone
+
+from brain.contracts import DeviceStatusV1, ObservationV1
+from brain.sources import ReplaySource, SyntheticConfig, SyntheticSource
+
+
+def _make_replay_file(tmp_path):
+    path = tmp_path / "obs.jsonl"
+    payload = {
+        "observation": {
+            "schema_version": "observation_v1",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "soil_moisture_p1": 0.5,
+            "soil_moisture_p2": 0.52,
+            "air_temperature": 22.0,
+            "air_humidity": 60.0,
+            "co2_ppm": 420.0,
+            "light_intensity": 300.0,
+        },
+        "device_status": {
+            "schema_version": "device_status_v1",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "light_on": True,
+            "fans_on": False,
+            "heater_on": False,
+            "pump_on": False,
+            "co2_on": False,
+            "mcu_connected": True,
+            "mcu_uptime_seconds": 120,
+            "mcu_reset_count": 0,
+            "light_intensity_setpoint": 300.0,
+            "pump_pulse_count": 0,
+        },
+    }
+    path.write_text(__import__("json").dumps(payload) + "\n", encoding="utf-8")
+    return path
+
+
+def test_sources_implement_next_observation_contract(tmp_path):
+    config = SyntheticConfig(count=1)
+    synthetic = SyntheticSource(config)
+    item = synthetic.next_observation()
+    assert item is not None
+    obs, device = item
+    assert isinstance(obs, ObservationV1)
+    assert isinstance(device, DeviceStatusV1)
+
+    replay_path = _make_replay_file(tmp_path)
+    replay = ReplaySource(str(replay_path))
+    item = replay.next_observation()
+    assert item is not None
+    obs, device = item
+    assert isinstance(obs, ObservationV1)
+    assert isinstance(device, DeviceStatusV1)

--- a/tests/sources/test_replay_source.py
+++ b/tests/sources/test_replay_source.py
@@ -1,0 +1,80 @@
+"""Tests for ReplaySource behavior."""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.sources import ReplaySource
+
+
+def _make_payload(index: int) -> dict:
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    return {
+        "observation": {
+            "schema_version": "observation_v1",
+            "timestamp": (now).isoformat(),
+            "soil_moisture_p1": 0.4 + index * 0.01,
+            "soil_moisture_p2": 0.5 + index * 0.01,
+            "air_temperature": 20.0 + index,
+            "air_humidity": 55.0,
+            "co2_ppm": 410.0,
+            "light_intensity": 250.0,
+        },
+        "device_status": {
+            "schema_version": "device_status_v1",
+            "timestamp": (now).isoformat(),
+            "light_on": True,
+            "fans_on": False,
+            "heater_on": False,
+            "pump_on": False,
+            "co2_on": False,
+            "mcu_connected": True,
+            "mcu_uptime_seconds": 60 * index,
+            "mcu_reset_count": 0,
+            "light_intensity_setpoint": 250.0,
+            "pump_pulse_count": 0,
+        },
+    }
+
+
+def test_reads_jsonl_in_order(tmp_path):
+    path = tmp_path / "obs.jsonl"
+    lines = [json.dumps(_make_payload(i)) for i in range(3)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    source = ReplaySource(str(path))
+    seq = [source.next_observation() for _ in range(3)]
+    assert [s[0].air_temperature for s in seq] == [20.0, 21.0, 22.0]
+
+
+def test_returns_none_after_eof(tmp_path):
+    path = tmp_path / "obs.jsonl"
+    path.write_text(json.dumps(_make_payload(0)) + "\n", encoding="utf-8")
+    source = ReplaySource(str(path))
+    assert source.next_observation() is not None
+    assert source.next_observation() is None
+    assert source.next_observation() is None
+
+
+def test_malformed_line_policy(tmp_path, caplog):
+    path = tmp_path / "obs.jsonl"
+    lines = [
+        json.dumps(_make_payload(0)),
+        "{not-json}",
+        json.dumps(_make_payload(1)),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    source = ReplaySource(str(path), malformed_policy="skip")
+    with caplog.at_level("WARNING"):
+        first = source.next_observation()
+        second = source.next_observation()
+    assert first is not None
+    assert second is not None
+    assert any("Malformed JSONL" in rec.message for rec in caplog.records)
+
+    source_fail = ReplaySource(str(path), malformed_policy="fail_fast")
+    assert source_fail.next_observation() is not None
+    with pytest.raises(ValueError):
+        source_fail.next_observation()

--- a/tests/sources/test_synthetic_source.py
+++ b/tests/sources/test_synthetic_source.py
@@ -1,0 +1,76 @@
+"""Tests for SyntheticSource behavior."""
+
+from datetime import datetime, timezone
+
+from brain.sources import SyntheticConfig, SyntheticSource
+
+
+def test_seeded_generation_is_deterministic():
+    config = SyntheticConfig(seed=123, count=3)
+    src_a = SyntheticSource(config)
+    src_b = SyntheticSource(config)
+
+    seq_a = [src_a.next_observation() for _ in range(3)]
+    seq_b = [src_b.next_observation() for _ in range(3)]
+
+    assert [a[0].model_dump() for a in seq_a] == [
+        b[0].model_dump() for b in seq_b
+    ]
+    assert [a[1].model_dump() for a in seq_a] == [
+        b[1].model_dump() for b in seq_b
+    ]
+
+
+def test_diurnal_cycle_affects_output():
+    midnight = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    noon = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+
+    config_night = SyntheticConfig(
+        seed=1,
+        count=1,
+        start_time=midnight,
+        noise_air_temperature=0.0,
+        noise_air_humidity=0.0,
+        noise_light_intensity=0.0,
+        diurnal_light_amp=1.0,
+    )
+    config_day = SyntheticConfig(
+        seed=1,
+        count=1,
+        start_time=noon,
+        noise_air_temperature=0.0,
+        noise_air_humidity=0.0,
+        noise_light_intensity=0.0,
+        diurnal_light_amp=1.0,
+    )
+
+    night_obs, _ = SyntheticSource(config_night).next_observation()
+    day_obs, _ = SyntheticSource(config_day).next_observation()
+
+    assert day_obs.light_intensity > night_obs.light_intensity
+
+
+def test_scenario_injection_changes_signal():
+    def scenario_hook(obs, device, rng, step_index):
+        return (
+            obs.model_copy(update={"air_temperature": 35.0}),
+            device,
+        )
+
+    config = SyntheticConfig(
+        seed=5,
+        count=1,
+        scenarios=[scenario_hook],
+        noise_air_temperature=0.0,
+    )
+    obs, _ = SyntheticSource(config).next_observation()
+    assert obs.air_temperature == 35.0
+
+
+def test_observations_match_observation_v1_schema():
+    config = SyntheticConfig(seed=99, count=5)
+    source = SyntheticSource(config)
+    for _ in range(5):
+        obs, device = source.next_observation()
+        assert obs.schema_version == "observation_v1"
+        assert device.schema_version == "device_status_v1"


### PR DESCRIPTION
## Summary
- add unified observation source interface and iterator
- implement SyntheticSource with seeded noise, diurnal cycle, and scenario hooks
- implement ReplaySource for JSONL with malformed-line policy and timestamp parsing
- add tests for contract, determinism, diurnal behavior, scenario injection, schema checks, ordering, EOF, and malformed handling

## Testing
- pytest tests\\sources -v