### PR TITLE
TOMATO-16: implement clock abstraction and scheduler

### DIFF
--- a/brain/clock/__init__.py
+++ b/brain/clock/__init__.py
@@ -1,0 +1,7 @@
+﻿"""Clock package exports."""
+
+from .clock import Clock
+from .real_clock import RealClock
+from .sim_clock import SimClock
+
+__all__ = ["Clock", "RealClock", "SimClock"]

--- a/brain/clock/clock.py
+++ b/brain/clock/clock.py
@@ -1,0 +1,19 @@
+﻿"""Clock interface used by schedulers and simulations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Clock interface for wall or simulated time."""
+
+    def now(self) -> datetime:
+        """Return the current time."""
+
+    def sleep(self, seconds: float) -> None:
+        """Advance time by the given seconds (or sleep in real time)."""
+
+    def sleep_for_logical(self, seconds: float) -> None:
+        """Advance the clock by logical seconds."""

--- a/brain/clock/real_clock.py
+++ b/brain/clock/real_clock.py
@@ -1,0 +1,21 @@
+﻿"""Wall-clock implementation."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+
+class RealClock:
+    """Clock backed by wall time."""
+
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def sleep(self, seconds: float) -> None:
+        if seconds <= 0:
+            return
+        time.sleep(seconds)
+
+    def sleep_for_logical(self, seconds: float) -> None:
+        self.sleep(seconds)

--- a/brain/clock/sim_clock.py
+++ b/brain/clock/sim_clock.py
@@ -1,0 +1,41 @@
+﻿"""Simulated clock with deterministic progression."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+class SimClock:
+    """Clock that advances logical time by a scale factor."""
+
+    def __init__(
+        self,
+        time_scale: float = 1.0,
+        start_time: datetime | None = None,
+    ) -> None:
+        if time_scale <= 0:
+            raise ValueError("time_scale must be positive")
+        if start_time is None:
+            start_time = datetime.now(timezone.utc)
+        if start_time.tzinfo is None:
+            raise ValueError("start_time must be timezone-aware")
+        self._time_scale = time_scale
+        self._current_time = start_time
+
+    @property
+    def time_scale(self) -> float:
+        return self._time_scale
+
+    def now(self) -> datetime:
+        return self._current_time
+
+    def sleep(self, seconds: float) -> None:
+        if seconds <= 0:
+            return
+        advance = seconds * self._time_scale
+        self._current_time = self._current_time + timedelta(seconds=advance)
+
+    def sleep_for_logical(self, seconds: float) -> None:
+        if seconds <= 0:
+            return
+        self._current_time = self._current_time + timedelta(seconds=seconds)

--- a/brain/scheduler/__init__.py
+++ b/brain/scheduler/__init__.py
@@ -1,0 +1,5 @@
+﻿"""Scheduler exports."""
+
+from .event_loop import Scheduler
+
+__all__ = ["Scheduler"]

--- a/brain/scheduler/event_loop.py
+++ b/brain/scheduler/event_loop.py
@@ -1,0 +1,81 @@
+﻿"""Event loop for periodic tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable, List
+
+from brain.clock import Clock
+
+
+@dataclass
+class PeriodicTask:
+    interval_seconds: float
+    callback: Callable[[datetime], None]
+    next_run: datetime
+    order: int
+    name: str | None = None
+
+
+class Scheduler:
+    """Deterministic scheduler driven by an injected clock."""
+
+    def __init__(self, clock: Clock) -> None:
+        self._clock = clock
+        self._tasks: List[PeriodicTask] = []
+        self._order = 0
+        self._stop = False
+
+    def schedule_every(
+        self, interval_seconds: float, callback: Callable[[datetime], None], name: str | None = None
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        now = self._clock.now()
+        next_run = now + timedelta(seconds=interval_seconds)
+        task = PeriodicTask(
+            interval_seconds=interval_seconds,
+            callback=callback,
+            next_run=next_run,
+            order=self._order,
+            name=name,
+        )
+        self._order += 1
+        self._tasks.append(task)
+
+    def shutdown(self) -> None:
+        """Request the scheduler to stop after the current task."""
+        self._stop = True
+
+    def run(self, duration_seconds: float) -> None:
+        """Run scheduled tasks for the given logical duration."""
+        if duration_seconds < 0:
+            raise ValueError("duration_seconds must be non-negative")
+        start = self._clock.now()
+        end = start + timedelta(seconds=duration_seconds)
+
+        if not self._tasks:
+            self._clock.sleep_for_logical(duration_seconds)
+            return
+
+        while not self._stop:
+            now = self._clock.now()
+            next_run = min(task.next_run for task in self._tasks)
+            if next_run > end:
+                self._clock.sleep_for_logical((end - now).total_seconds())
+                break
+            if next_run > now:
+                self._clock.sleep_for_logical((next_run - now).total_seconds())
+                now = self._clock.now()
+
+            due = [task for task in self._tasks if task.next_run <= now]
+            due.sort(key=lambda task: (task.next_run, task.order))
+
+            for task in due:
+                task.callback(now)
+                task.next_run = task.next_run + timedelta(
+                    seconds=task.interval_seconds
+                )
+                if self._stop:
+                    break

--- a/tests/clock/test_real_clock.py
+++ b/tests/clock/test_real_clock.py
@@ -1,0 +1,11 @@
+﻿"""Tests for RealClock."""
+
+from brain.clock import RealClock
+
+
+def test_real_clock_monotonicity():
+    clock = RealClock()
+    first = clock.now()
+    clock.sleep(0.01)
+    second = clock.now()
+    assert second >= first

--- a/tests/clock/test_sim_clock.py
+++ b/tests/clock/test_sim_clock.py
@@ -1,0 +1,14 @@
+﻿"""Tests for SimClock."""
+
+from datetime import datetime, timedelta, timezone
+
+from brain.clock import SimClock
+
+
+def test_sim_clock_advances_by_scale():
+    start = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    clock = SimClock(time_scale=120.0, start_time=start)
+
+    clock.sleep(1.5)
+
+    assert clock.now() == start + timedelta(seconds=180)

--- a/tests/scheduler/test_event_loop.py
+++ b/tests/scheduler/test_event_loop.py
@@ -1,0 +1,52 @@
+﻿"""Tests for scheduler event loop."""
+
+from datetime import datetime, timedelta, timezone
+
+from brain.clock import SimClock
+from brain.scheduler import Scheduler
+
+
+def test_periodic_task_execution_order():
+    start = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    clock = SimClock(time_scale=60.0, start_time=start)
+    scheduler = Scheduler(clock)
+    events: list[str] = []
+
+    scheduler.schedule_every(10.0, lambda now: events.append("a"))
+    scheduler.schedule_every(15.0, lambda now: events.append("b"))
+
+    scheduler.run(duration_seconds=30.0)
+
+    assert events == ["a", "b", "a", "a", "b"]
+
+
+def test_two_hour_logical_cycle_completion():
+    start = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    clock = SimClock(time_scale=120.0, start_time=start)
+    scheduler = Scheduler(clock)
+    ticks: list[datetime] = []
+
+    scheduler.schedule_every(7200.0, lambda now: ticks.append(now))
+
+    scheduler.run(duration_seconds=24 * 3600)
+
+    assert len(ticks) == 12
+    assert ticks[-1] == start + timedelta(hours=24)
+
+
+def test_graceful_shutdown():
+    start = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    clock = SimClock(time_scale=10.0, start_time=start)
+    scheduler = Scheduler(clock)
+    calls: list[str] = []
+
+    def stop_task(_now):
+        calls.append("stop")
+        scheduler.shutdown()
+
+    scheduler.schedule_every(5.0, stop_task)
+    scheduler.schedule_every(5.0, lambda now: calls.append("other"))
+
+    scheduler.run(duration_seconds=60.0)
+
+    assert calls == ["stop"]


### PR DESCRIPTION
## Summary
- add clock abstraction with RealClock and SimClock
- add deterministic scheduler for periodic tasks
- add clock/scheduler test suite

## Testing
- pytest tests\\clock tests\\scheduler -v

## Notes
- Issue #16 title appears to reference TOMATO-17; using TOMATO-16 prefix to match issue number.