### PR TITLE
TOMATO-16: add simulate_day script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ ruff check .
 ruff check . --fix
 
 # Simulate 24-hour day (accelerated time)
-python scripts/simulate_day.py
+python scripts/simulate_day.py --seed 42 --duration-hours 24 --time-scale 120 --output-dir data/runs
 ```
+
+Main loop (every 2 hours): observation → estimate → store → advance.
 
 ---
 

--- a/scripts/simulate_day.py
+++ b/scripts/simulate_day.py
@@ -1,0 +1,185 @@
+﻿"""Run a 24h simulated day using synthetic observations."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from brain.clock import SimClock
+from brain.estimator import EstimatorPipeline
+from brain.scheduler import Scheduler
+from brain.sources import SyntheticConfig, SyntheticSource
+from brain.storage.dataset import DatasetManager
+from brain.storage.jsonl_writer import JSONLWriter
+
+DEFAULT_STEP_SECONDS = 2 * 60 * 60
+SEEDED_START_TIME = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value
+
+
+def _scenario_hooks(name: str | None) -> list[Callable]:
+    if not name or name == "none":
+        return []
+
+    def heatwave(obs, device, _rng, _index):
+        temp = obs.air_temperature + 6.0
+        rh = _clamp(obs.air_humidity - 10.0, 0.0, 100.0)
+        return obs.model_copy(update={"air_temperature": temp, "air_humidity": rh}), device
+
+    def dry_inflow(obs, device, _rng, _index):
+        temp = obs.air_temperature + 3.0
+        rh = _clamp(obs.air_humidity - 15.0, 0.0, 100.0)
+        return obs.model_copy(update={"air_temperature": temp, "air_humidity": rh}), device
+
+    def wind_spike(obs, device, _rng, _index):
+        rh = _clamp(obs.air_humidity - 5.0, 0.0, 100.0)
+        return obs.model_copy(update={"air_humidity": rh}), device
+
+    def cold_spell(obs, device, _rng, _index):
+        temp = obs.air_temperature - 6.0
+        rh = _clamp(obs.air_humidity + 10.0, 0.0, 100.0)
+        return obs.model_copy(update={"air_temperature": temp, "air_humidity": rh}), device
+
+    hooks = {
+        "heatwave": heatwave,
+        "dry_inflow": dry_inflow,
+        "wind_spike": wind_spike,
+        "cold_spell": cold_spell,
+    }
+
+    if name not in hooks:
+        raise ValueError(f"Unsupported scenario '{name}'")
+    return [hooks[name]]
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a simulated day with synthetic observations.",
+    )
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--output-dir", type=str, default="data/runs")
+    parser.add_argument("--duration-hours", type=float, default=24.0)
+    parser.add_argument("--time-scale", type=float, default=120.0)
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        default="none",
+        choices=["none", "heatwave", "dry_inflow", "wind_spike", "cold_spell"],
+    )
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+
+
+def run_simulation(args: argparse.Namespace) -> Path:
+    if args.duration_hours <= 0:
+        raise ValueError("duration-hours must be positive")
+    if args.time_scale <= 0:
+        raise ValueError("time-scale must be positive")
+
+    steps = int((args.duration_hours * 3600) // DEFAULT_STEP_SECONDS)
+    if steps < 1:
+        raise ValueError("duration-hours must be at least 2.0")
+
+    start_time = SEEDED_START_TIME if args.seed is not None else datetime.now(timezone.utc)
+
+    config = SyntheticConfig(
+        seed=args.seed,
+        start_time=start_time,
+        step_seconds=DEFAULT_STEP_SECONDS,
+        count=steps,
+        scenarios=_scenario_hooks(args.scenario),
+    )
+    source = SyntheticSource(config)
+    pipeline = EstimatorPipeline()
+
+    dataset = DatasetManager(args.output_dir)
+    run_dir = dataset.create_run_dir(run_date=start_time.date())
+
+    state_path = run_dir / "state.jsonl"
+    anomalies_path = run_dir / "anomalies.jsonl"
+    health_path = run_dir / "sensor_health.jsonl"
+    observations_path = run_dir / "observations.jsonl"
+
+    _touch(anomalies_path)
+    _touch(health_path)
+
+    state_writer = JSONLWriter(str(state_path))
+    anomaly_writer = JSONLWriter(str(anomalies_path))
+    health_writer = JSONLWriter(str(health_path))
+    observations_writer = JSONLWriter(str(observations_path))
+
+    clock = SimClock(time_scale=1.0, start_time=start_time)
+    scheduler = Scheduler(clock)
+
+    # Main loop (every 2 hours): obs -> estimate -> store -> advance
+    def cycle(_now):
+        item = source.next_observation()
+        if item is None:
+            scheduler.shutdown()
+            return
+        observation, device_status = item
+
+        observations_writer.append(
+            {
+                "observation": observation.model_dump(mode="json"),
+                "device_status": device_status.model_dump(mode="json"),
+            }
+        )
+
+        state, anomalies, sensor_health = pipeline.process(
+            observation, device_status
+        )
+        state_writer.append(state.model_dump(mode="json"))
+        for anomaly in anomalies:
+            anomaly_writer.append(anomaly.model_dump(mode="json"))
+        for health in sensor_health:
+            health_writer.append(health.model_dump(mode="json"))
+
+        if args.verbose:
+            print(
+                f"{observation.timestamp.isoformat()} | "
+                f"confidence={state.confidence:.2f} "
+                f"anomalies={len(anomalies)}"
+            )
+
+        wall_sleep = DEFAULT_STEP_SECONDS / args.time_scale
+        if wall_sleep > 0:
+            time.sleep(wall_sleep)
+
+    scheduler.schedule_every(DEFAULT_STEP_SECONDS, cycle, name="decision_cycle")
+    scheduler.run(duration_seconds=steps * DEFAULT_STEP_SECONDS)
+
+    return run_dir
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    try:
+        run_dir = run_simulation(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"simulate_day failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.verbose:
+        print(f"Run output: {run_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/scripts/test_simulate_day_cli.py
+++ b/tests/scripts/test_simulate_day_cli.py
@@ -1,0 +1,48 @@
+﻿"""CLI tests for simulate_day script."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(args, cwd: Path):
+    return subprocess.run(
+        [sys.executable, "scripts/simulate_day.py", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_help_contains_required_arguments(tmp_path):
+    result = _run(["--help"], cwd=Path.cwd())
+    assert result.returncode == 0
+    for flag in [
+        "--seed",
+        "--output-dir",
+        "--duration-hours",
+        "--time-scale",
+        "--scenario",
+        "--verbose",
+    ]:
+        assert flag in result.stdout
+
+
+def test_all_cli_arguments_are_valid(tmp_path):
+    result = _run(
+        [
+            "--seed",
+            "123",
+            "--output-dir",
+            str(tmp_path),
+            "--duration-hours",
+            "2",
+            "--time-scale",
+            "1000000",
+            "--scenario",
+            "none",
+            "--verbose",
+        ],
+        cwd=Path.cwd(),
+    )
+    assert result.returncode == 0

--- a/tests/scripts/test_simulate_day_run.py
+++ b/tests/scripts/test_simulate_day_run.py
@@ -1,0 +1,95 @@
+﻿"""Integration-style tests for simulate_day outputs."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_simulate(output_dir: Path, extra_args: list[str]) -> subprocess.CompletedProcess:
+    args = [
+        sys.executable,
+        "scripts/simulate_day.py",
+        "--output-dir",
+        str(output_dir),
+    ] + extra_args
+    return subprocess.run(args, cwd=Path.cwd(), capture_output=True, text=True)
+
+
+def _find_run_dir(output_dir: Path) -> Path:
+    runs = [p for p in output_dir.iterdir() if p.is_dir() and p.name.startswith("run_")]
+    assert len(runs) == 1
+    return runs[0]
+
+
+def _read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8").strip()
+    return [] if not text else text.splitlines()
+
+
+def test_generates_state_and_anomaly_logs(tmp_path):
+    result = _run_simulate(
+        tmp_path,
+        ["--duration-hours", "2", "--seed", "123", "--time-scale", "1000000"],
+    )
+    assert result.returncode == 0
+
+    run_dir = _find_run_dir(tmp_path)
+    state_path = run_dir / "state.jsonl"
+    anomaly_path = run_dir / "anomalies.jsonl"
+    observations_path = run_dir / "observations.jsonl"
+
+    assert state_path.exists()
+    assert anomaly_path.exists()
+    assert observations_path.exists()
+    assert len(_read_lines(state_path)) >= 1
+
+
+def test_time_scale_does_not_change_logical_count(tmp_path):
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+
+    result_a = _run_simulate(
+        out_a,
+        ["--duration-hours", "4", "--seed", "7", "--time-scale", "1000000"],
+    )
+    result_b = _run_simulate(
+        out_b,
+        ["--duration-hours", "4", "--seed", "7", "--time-scale", "2000000"],
+    )
+
+    assert result_a.returncode == 0
+    assert result_b.returncode == 0
+
+    run_a = _find_run_dir(out_a)
+    run_b = _find_run_dir(out_b)
+
+    count_a = len(_read_lines(run_a / "state.jsonl"))
+    count_b = len(_read_lines(run_b / "state.jsonl"))
+
+    assert count_a == count_b
+
+
+def test_fixed_seed_produces_reproducible_outputs(tmp_path):
+    out_a = tmp_path / "run_a"
+    out_b = tmp_path / "run_b"
+
+    result_a = _run_simulate(
+        out_a,
+        ["--duration-hours", "4", "--seed", "42", "--time-scale", "1000000"],
+    )
+    result_b = _run_simulate(
+        out_b,
+        ["--duration-hours", "4", "--seed", "42", "--time-scale", "1000000"],
+    )
+
+    assert result_a.returncode == 0
+    assert result_b.returncode == 0
+
+    run_a = _find_run_dir(out_a)
+    run_b = _find_run_dir(out_b)
+
+    assert (run_a / "state.jsonl").read_text(encoding="utf-8") == (
+        run_b / "state.jsonl"
+    ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add scripts/simulate_day.py with CLI args and 2-hour main loop
- write replay-compatible observation/state/anomaly outputs
- add CLI/run tests and README example

## Testing
- pytest tests\\scripts -v