### PR TITLE
TOMATO-18: add 24h deterministic SimClock integration test

### DIFF
--- a/brain/estimator/anomaly_detector.py
+++ b/brain/estimator/anomaly_detector.py
@@ -156,12 +156,17 @@ def detect_anomalies(
             anomaly_type = AnomalyType.SENSOR_DISCONNECT
         else:
             anomaly_type = AnomalyType.UNKNOWN
+        fault_label = (
+            health.fault_state.value
+            if hasattr(health.fault_state, "value")
+            else str(health.fault_state)
+        )
         anomalies.append(
             _make_anomaly(
                 now,
                 anomaly_type,
                 _severity_for_fault(health.fault_state),
-                f"Sensor fault detected: {health.fault_state.value}",
+                f"Sensor fault detected: {fault_label}",
                 affected_sensor=health.sensor_name,
             )
         )


### PR DESCRIPTION
## Summary
- add 24h deterministic simulation integration test
- validate JSONL outputs against contracts
- ensure deterministic output for fixed seed
- fix anomaly fault label formatting

## Testing
- pytest tests\\integration -v