### PR TITLE
TOMATO-30: Implement StateV1 weather-adapter bridge mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The goal is to build an open embodied AI system that the community can inspect a
 - `docs/confidence_scoring.md`
 - `docs/anomaly_thresholds.md`
 - `docs/error_handling.md`
+- `docs/state_v1_weather_adapter_mapping.md`
 
 ---
 

--- a/brain/world_model/__init__.py
+++ b/brain/world_model/__init__.py
@@ -1,0 +1,11 @@
+"""World model utilities and adapters."""
+
+from .state_v1_weather_adapter_mapper import (
+    WeatherAdapterStateInputV1,
+    map_state_v1_to_weather_adapter_input,
+)
+
+__all__ = [
+    "WeatherAdapterStateInputV1",
+    "map_state_v1_to_weather_adapter_input",
+]

--- a/brain/world_model/state_v1_weather_adapter_mapper.py
+++ b/brain/world_model/state_v1_weather_adapter_mapper.py
@@ -1,0 +1,135 @@
+"""Bridge mapper from flat StateV1 to weather-adapter nested input."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from brain.contracts import StateV1
+
+
+class WeatherAdapterProbeV1(BaseModel):
+    """Single soil probe payload for weather-adapter input."""
+
+    model_config = ConfigDict(strict=True)
+
+    probe_id: str = Field(description="Probe identifier (for example p1, p2).")
+    moisture_pct: float = Field(
+        ge=0.0,
+        le=100.0,
+        description="Probe moisture in percent (0-100).",
+    )
+
+
+class WeatherAdapterEnvV1(BaseModel):
+    """Nested environmental data expected by weather adapter."""
+
+    model_config = ConfigDict(strict=True)
+
+    air_temp_c: float = Field(description="Air temperature in Celsius.")
+    rh_pct: float = Field(
+        ge=0.0,
+        le=100.0,
+        description="Relative humidity percentage (0-100).",
+    )
+    vpd_kpa: float = Field(
+        ge=0.0,
+        description="Vapor Pressure Deficit in kPa.",
+    )
+    co2_ppm: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="CO2 concentration in ppm.",
+    )
+    light_umol_m2_s: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Light intensity in umol/m^2/s.",
+    )
+
+
+class WeatherAdapterSoilV1(BaseModel):
+    """Nested soil data expected by weather adapter."""
+
+    model_config = ConfigDict(strict=True)
+
+    avg_moisture_pct: float = Field(
+        ge=0.0,
+        le=100.0,
+        description="Average soil moisture in percent (0-100).",
+    )
+    probes: list[WeatherAdapterProbeV1] = Field(
+        min_length=1,
+        description="Available soil probe measurements.",
+    )
+
+
+class WeatherAdapterStateInputV1(BaseModel):
+    """Normalized state payload consumed by Stage 3 weather adapter."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["weather_adapter_state_input_v1"]
+    source_schema_version: Literal["state_v1"]
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp with timezone, copied from StateV1.",
+    )
+    env: WeatherAdapterEnvV1
+    soil: WeatherAdapterSoilV1
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="State-level confidence copied from StateV1.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, value: datetime) -> datetime:
+        """Ensure timestamp is timezone-aware."""
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value
+
+
+def map_state_v1_to_weather_adapter_input(
+    state: StateV1,
+) -> WeatherAdapterStateInputV1:
+    """
+    Map flat StateV1 fields to nested weather-adapter schema.
+
+    This function performs post-map validation by constructing
+    `WeatherAdapterStateInputV1` before returning.
+    """
+    probes = [
+        WeatherAdapterProbeV1(
+            probe_id="p1",
+            moisture_pct=state.soil_moisture_p1 * 100.0,
+        )
+    ]
+    if state.soil_moisture_p2 is not None:
+        probes.append(
+            WeatherAdapterProbeV1(
+                probe_id="p2",
+                moisture_pct=state.soil_moisture_p2 * 100.0,
+            )
+        )
+
+    return WeatherAdapterStateInputV1(
+        schema_version="weather_adapter_state_input_v1",
+        source_schema_version="state_v1",
+        timestamp=state.timestamp,
+        env=WeatherAdapterEnvV1(
+            air_temp_c=state.air_temperature,
+            rh_pct=state.air_humidity,
+            vpd_kpa=state.vpd,
+            co2_ppm=state.co2_ppm,
+            light_umol_m2_s=state.light_intensity,
+        ),
+        soil=WeatherAdapterSoilV1(
+            avg_moisture_pct=state.soil_moisture_avg * 100.0,
+            probes=probes,
+        ),
+        confidence=state.confidence,
+    )

--- a/docs/state_v1_weather_adapter_mapping.md
+++ b/docs/state_v1_weather_adapter_mapping.md
@@ -1,0 +1,40 @@
+# StateV1 to Weather Adapter Mapping
+
+This document defines the deterministic bridge from flat `StateV1` to the
+Stage 3 weather-adapter nested input schema.
+
+Implementation: `brain/world_model/state_v1_weather_adapter_mapper.py`
+
+## Target Schema
+
+- `schema_version`: `weather_adapter_state_input_v1`
+- `source_schema_version`: `state_v1`
+- `timestamp`: timezone-aware ISO8601 datetime
+- `confidence`: float in `[0, 1]`
+- `env`: nested environment fields
+- `soil`: nested soil fields and probes
+
+## Field Mapping and Units
+
+- `schema_version` <- constant `"weather_adapter_state_input_v1"`
+- `source_schema_version` <- constant `"state_v1"`
+- `timestamp` <- `StateV1.timestamp` (no conversion)
+- `confidence` <- `StateV1.confidence` (no conversion)
+- `env.air_temp_c` <- `StateV1.air_temperature` (Celsius, no conversion)
+- `env.rh_pct` <- `StateV1.air_humidity` (percent, no conversion)
+- `env.vpd_kpa` <- `StateV1.vpd` (kPa, no conversion)
+- `env.co2_ppm` <- `StateV1.co2_ppm` (ppm, optional passthrough)
+- `env.light_umol_m2_s` <- `StateV1.light_intensity` (umol/m^2/s, optional passthrough)
+- `soil.avg_moisture_pct` <- `StateV1.soil_moisture_avg * 100`
+- `soil.probes[0]` <- `StateV1.soil_moisture_p1 * 100` with `probe_id="p1"`
+- `soil.probes[1]` <- `StateV1.soil_moisture_p2 * 100` with `probe_id="p2"` when present
+
+## Validation Rules
+
+Post-map validation is performed by constructing `WeatherAdapterStateInputV1`.
+Validation enforces:
+
+- required nested fields (`env`, `soil`, and at least one probe),
+- numeric ranges (`rh_pct` in `[0,100]`, moisture in `[0,100]`, `vpd_kpa >= 0`),
+- timezone-aware `timestamp`,
+- bounded `confidence` in `[0,1]`.

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -56,6 +56,15 @@ class TestSpecificationDocuments:
         lower = content.lower()
         assert "fail-fast" in lower or "fail fast" in lower
 
+    def test_state_v1_weather_adapter_mapping_doc_exists(self):
+        """Mapper documentation should define field and unit transformations."""
+        doc_path = Path("docs/state_v1_weather_adapter_mapping.md")
+        assert doc_path.exists(), "docs/state_v1_weather_adapter_mapping.md not found"
+        content = doc_path.read_text(encoding="utf-8")
+        assert "Field Mapping and Units" in content
+        assert "StateV1.soil_moisture_avg * 100" in content
+        assert "brain/world_model/state_v1_weather_adapter_mapper.py" in content
+
     def test_agents_status_consistency(self):
         """AGENTS status blocks should match implemented Stage 1 components."""
         content = Path("AGENTS.md").read_text(encoding="utf-8")
@@ -92,6 +101,7 @@ class TestSpecificationDocuments:
             Path("docs/confidence_scoring.md"),
             Path("docs/anomaly_thresholds.md"),
             Path("docs/error_handling.md"),
+            Path("docs/state_v1_weather_adapter_mapping.md"),
         ]
 
         for path in docs:

--- a/tests/world_model/test_state_v1_weather_adapter_mapper.py
+++ b/tests/world_model/test_state_v1_weather_adapter_mapper.py
@@ -1,0 +1,53 @@
+"""Tests for StateV1 -> weather-adapter mapper."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.contracts import StateV1
+from brain.world_model import map_state_v1_to_weather_adapter_input
+
+
+def _state(**overrides) -> StateV1:
+    payload = {
+        "schema_version": "state_v1",
+        "timestamp": datetime(2026, 2, 15, 10, 0, tzinfo=timezone.utc),
+        "soil_moisture_p1": 0.61,
+        "soil_moisture_p2": 0.57,
+        "soil_moisture_avg": 0.59,
+        "air_temperature": 23.5,
+        "air_humidity": 62.0,
+        "vpd": 1.1,
+        "co2_ppm": 450.0,
+        "light_intensity": 320.0,
+        "confidence": 0.93,
+    }
+    payload.update(overrides)
+    return StateV1(**payload)
+
+
+def test_flat_to_nested_mapping():
+    state = _state()
+    mapped = map_state_v1_to_weather_adapter_input(state)
+
+    assert mapped.schema_version == "weather_adapter_state_input_v1"
+    assert mapped.source_schema_version == "state_v1"
+    assert mapped.timestamp == state.timestamp
+    assert mapped.env.air_temp_c == 23.5
+    assert mapped.env.rh_pct == 62.0
+    assert mapped.env.vpd_kpa == 1.1
+    assert mapped.soil.avg_moisture_pct == 59.0
+    assert [probe.probe_id for probe in mapped.soil.probes] == ["p1", "p2"]
+    assert [probe.moisture_pct for probe in mapped.soil.probes] == pytest.approx(
+        [61.0, 57.0]
+    )
+    assert mapped.confidence == 0.93
+
+
+def test_missing_optional_fields_handled():
+    state = _state(soil_moisture_p2=None, co2_ppm=None, light_intensity=None)
+    mapped = map_state_v1_to_weather_adapter_input(state)
+
+    assert [probe.probe_id for probe in mapped.soil.probes] == ["p1"]
+    assert mapped.env.co2_ppm is None
+    assert mapped.env.light_umol_m2_s is None


### PR DESCRIPTION
## Summary
- add deterministic StateV1 -> weather_adapter_state_input_v1 bridge mapper in rain/world_model/state_v1_weather_adapter_mapper.py`n- add nested adapter input models with post-map validation for required fields and ranges
- add mapper package export via rain/world_model/__init__.py`n- document exact field mapping and unit conversions in docs/state_v1_weather_adapter_mapping.md`n- add unit tests for flat-to-nested mapping and optional field handling in 	ests/world_model/test_state_v1_weather_adapter_mapper.py`n
## Testing
- pytest tests/world_model/test_state_v1_weather_adapter_mapper.py tests/test_specs.py -q -p no:cacheprovider -o addopts=''

Closes #35