### PR TITLE
TOMATO-37: add baseline water-only control flow

### DIFF
--- a/brain/control/__init__.py
+++ b/brain/control/__init__.py
@@ -1,0 +1,15 @@
+"""Stage 2 control policies.
+
+Current Stage 2 scope is intentionally water-only. Other action types
+(light/fan/co2/circulate) are deferred to later stages.
+"""
+
+from .baseline_water_controller import (
+    BaselineWaterControlConfig,
+    BaselineWaterController,
+)
+
+__all__ = [
+    "BaselineWaterControlConfig",
+    "BaselineWaterController",
+]

--- a/brain/control/baseline_water_controller.py
+++ b/brain/control/baseline_water_controller.py
@@ -1,0 +1,73 @@
+"""Deterministic baseline controller for Stage 2 water-only actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from brain.contracts import ActionV1, StateV1
+from brain.contracts.action_v1 import ActionType
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value
+
+
+@dataclass(frozen=True)
+class BaselineWaterControlConfig:
+    """Configuration for water-only baseline policy."""
+
+    trigger_threshold: float = 0.42
+    target_moisture: float = 0.55
+    min_duration_seconds: float = 8.0
+    max_duration_seconds: float = 40.0
+    intensity: float = 0.8
+
+
+class BaselineWaterController:
+    """Propose deterministic water actions from StateV1 snapshots.
+
+    Stage 2 intentionally emits only `ActionType.WATER`. All other action
+    types are deferred to next stages.
+    """
+
+    def __init__(self, config: BaselineWaterControlConfig | None = None) -> None:
+        self._config = config or BaselineWaterControlConfig()
+
+    def propose_action(
+        self,
+        state: StateV1,
+        *,
+        now: datetime | None = None,
+    ) -> ActionV1 | None:
+        """Return a water action when p1 moisture is below trigger threshold."""
+        if state.soil_moisture_p1 >= self._config.trigger_threshold:
+            return None
+
+        timestamp = now or state.timestamp
+        moisture_deficit = max(0.0, self._config.target_moisture - state.soil_moisture_p1)
+        normalized_deficit = _clamp(
+            moisture_deficit / max(self._config.target_moisture, 1e-9), 0.0, 1.0
+        )
+        duration_seconds = self._config.min_duration_seconds + normalized_deficit * (
+            self._config.max_duration_seconds - self._config.min_duration_seconds
+        )
+
+        return ActionV1(
+            schema_version="action_v1",
+            timestamp=timestamp,
+            action_type=ActionType.WATER,
+            duration_seconds=round(duration_seconds, 3),
+            intensity=self._config.intensity,
+            reason=(
+                "Stage 2 water-only policy: soil_moisture_p1 "
+                f"({state.soil_moisture_p1:.3f}) below trigger "
+                f"({self._config.trigger_threshold:.3f})."
+            ),
+            estimated_impact=round(normalized_deficit, 3),
+            confidence=state.confidence,
+        )

--- a/tests/control/test_baseline_water_controller.py
+++ b/tests/control/test_baseline_water_controller.py
@@ -1,0 +1,68 @@
+"""Unit tests for Stage 2 water-only baseline controller."""
+
+from datetime import datetime, timezone
+
+from brain.control import BaselineWaterController
+from brain.contracts import StateV1
+
+
+def _make_state(soil_moisture_p1: float) -> StateV1:
+    return StateV1(
+        schema_version="state_v1",
+        timestamp=datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc),
+        soil_moisture_p1=soil_moisture_p1,
+        soil_moisture_p2=soil_moisture_p1,
+        soil_moisture_avg=soil_moisture_p1,
+        air_temperature=22.0,
+        air_humidity=60.0,
+        vpd=1.0,
+        co2_ppm=420.0,
+        light_intensity=400.0,
+        confidence=0.9,
+        notes=None,
+    )
+
+
+def test_no_action_when_soil_is_above_threshold():
+    controller = BaselineWaterController()
+    state = _make_state(soil_moisture_p1=0.60)
+
+    assert controller.propose_action(state) is None
+
+
+def test_water_action_when_soil_is_below_threshold():
+    controller = BaselineWaterController()
+    state = _make_state(soil_moisture_p1=0.20)
+
+    action = controller.propose_action(state)
+
+    assert action is not None
+    assert action.action_type == "water"
+    assert action.duration_seconds is not None
+    assert action.duration_seconds > 0
+    assert action.reason is not None
+    assert "Stage 2 water-only policy" in action.reason
+
+
+def test_action_output_is_deterministic_for_identical_inputs():
+    controller = BaselineWaterController()
+    state = _make_state(soil_moisture_p1=0.25)
+    now = datetime(2026, 2, 15, 6, 0, tzinfo=timezone.utc)
+
+    action_a = controller.propose_action(state, now=now)
+    action_b = controller.propose_action(state, now=now)
+
+    assert action_a is not None
+    assert action_b is not None
+    assert action_a.model_dump(mode="json") == action_b.model_dump(mode="json")
+
+
+def test_duration_stays_within_configured_bounds():
+    controller = BaselineWaterController()
+    state = _make_state(soil_moisture_p1=0.0)
+
+    action = controller.propose_action(state)
+
+    assert action is not None
+    assert action.duration_seconds is not None
+    assert 8.0 <= action.duration_seconds <= 40.0

--- a/tests/integration/test_24h_deterministic_run.py
+++ b/tests/integration/test_24h_deterministic_run.py
@@ -5,7 +5,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-from brain.contracts import AnomalyV1, DeviceStatusV1, ObservationV1, SensorHealthV1, StateV1
+from brain.contracts import (
+    ActionV1,
+    AnomalyV1,
+    DeviceStatusV1,
+    ObservationV1,
+    SensorHealthV1,
+    StateV1,
+)
 
 
 def _run_simulate(
@@ -82,6 +89,9 @@ def test_24h_run_outputs_validate_against_contracts(tmp_path):
         ObservationV1.model_validate(payload["observation"], strict=False)
         DeviceStatusV1.model_validate(payload["device_status"], strict=False)
 
+    for payload in _load_jsonl(run_dir / "actions.jsonl"):
+        ActionV1.model_validate(payload, strict=False)
+
 
 def test_24h_run_is_deterministic_with_fixed_seed(tmp_path):
     out_a = tmp_path / "a"
@@ -113,6 +123,7 @@ def test_24h_run_jsonl_files_are_readable(tmp_path):
         "sensor_health.jsonl",
         "observations.jsonl",
         "cadence.jsonl",
+        "actions.jsonl",
     ]:
         path = run_dir / name
         for line in _read_lines(path):
@@ -137,6 +148,7 @@ def test_24h_run_all_artifacts_are_deterministic(tmp_path):
         "anomalies.jsonl",
         "sensor_health.jsonl",
         "observations.jsonl",
+        "actions.jsonl",
     ]:
         left = (run_a / artifact).read_text(encoding="utf-8")
         right = (run_b / artifact).read_text(encoding="utf-8")

--- a/tests/scripts/test_simulate_day_run.py
+++ b/tests/scripts/test_simulate_day_run.py
@@ -44,11 +44,18 @@ def test_generates_state_and_anomaly_logs(tmp_path):
     state_path = run_dir / "state.jsonl"
     anomaly_path = run_dir / "anomalies.jsonl"
     observations_path = run_dir / "observations.jsonl"
+    actions_path = run_dir / "actions.jsonl"
 
     assert state_path.exists()
     assert anomaly_path.exists()
     assert observations_path.exists()
+    assert actions_path.exists()
     assert len(_read_lines(state_path)) >= 1
+
+    action_records = _load_jsonl(actions_path)
+    for record in action_records:
+        assert record["schema_version"] == "action_v1"
+        assert record["action_type"] == "water"
 
 
 def test_time_scale_does_not_change_logical_count(tmp_path):


### PR DESCRIPTION
## Summary
- add Stage 2 `brain/control` module with deterministic water-only baseline controller
- integrate control proposal into `scripts/simulate_day.py` and persist `actions.jsonl`
- add controller unit tests and extend script/integration tests for `actions.jsonl` readability, determinism, and contract validation

## Scope Notes
- Stage 2 intentionally emits only `ActionType.WATER`
- other action types (`light`, `fan`, `co2`, `circulate`) are deferred to later stages

## Testing
- `pytest -q -o addopts='' tests/control/test_baseline_water_controller.py tests/scripts/test_simulate_day_run.py tests/integration/test_24h_deterministic_run.py`
- result: `15 passed`

Closes #45