### PR TITLE
TOMATO-50: add weather client and forecast_36h normalization

### DIFF
--- a/brain/contracts/__init__.py
+++ b/brain/contracts/__init__.py
@@ -9,6 +9,7 @@ from .action_v1 import ActionV1
 from .anomaly_v1 import AnomalyV1
 from .device_status_v1 import DeviceStatusV1
 from .executor_event_v1 import ExecutorEventV1
+from .forecast_36h_v1 import Forecast36hV1
 from .guardrail_result_v1 import GuardrailResultV1
 from .observation_v1 import ObservationV1
 from .sensor_health_v1 import SensorHealthV1
@@ -23,4 +24,5 @@ __all__ = [
     "DeviceStatusV1",
     "GuardrailResultV1",
     "ExecutorEventV1",
+    "Forecast36hV1",
 ]

--- a/brain/contracts/forecast_36h_v1.py
+++ b/brain/contracts/forecast_36h_v1.py
@@ -1,0 +1,99 @@
+"""Forecast36hV1: normalized weather forecast contract for Stage 3 ingestion."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class ForecastPointV1(BaseModel):
+    """Single forecast point at a fixed cadence."""
+
+    model_config = ConfigDict(strict=True)
+
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp for this forecast point.",
+    )
+    ext_temp_c: float = Field(description="External air temperature in Celsius.")
+    ext_rh_pct: float = Field(
+        ge=0.0,
+        le=100.0,
+        description="External relative humidity percentage (0-100).",
+    )
+    ext_wind_mps: float = Field(
+        ge=0.0,
+        description="External wind speed in m/s.",
+    )
+    ext_cloud_cover_pct: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=100.0,
+        description="External cloud cover percentage (0-100).",
+    )
+    ext_solar_wm2: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="External solar radiation in W/m^2.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, value: datetime) -> datetime:
+        """Ensure forecast timestamps are timezone-aware."""
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value
+
+    @model_validator(mode="after")
+    def validate_cloud_or_solar_present(self) -> "ForecastPointV1":
+        """At least one sky/solar signal must be present."""
+        if self.ext_cloud_cover_pct is None and self.ext_solar_wm2 is None:
+            raise ValueError("either ext_cloud_cover_pct or ext_solar_wm2 must be provided")
+        return self
+
+
+class Forecast36hV1(BaseModel):
+    """Normalized weather forecast for Stage 3 world-model ingestion."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["forecast_36h_v1"]
+    generated_at: datetime = Field(
+        description="Timestamp when forecast normalization was produced.",
+    )
+    source: str = Field(description="Source name for normalized forecast data.")
+    timezone: str = Field(description="IANA timezone name for timestamps.")
+    freq_minutes: int = Field(
+        ge=1,
+        description="Forecast cadence in minutes (typically 60).",
+    )
+    horizon_hours: int = Field(
+        ge=1,
+        le=36,
+        description="Forecast horizon in hours.",
+    )
+    points: list[ForecastPointV1] = Field(
+        min_length=1,
+        max_length=36,
+        description="Ordered forecast points for the horizon.",
+    )
+
+    @field_validator("generated_at")
+    @classmethod
+    def validate_generated_at_has_timezone(cls, value: datetime) -> datetime:
+        """Ensure generated_at is timezone-aware."""
+        if value.tzinfo is None:
+            raise ValueError("generated_at must include timezone info")
+        return value
+
+    @model_validator(mode="after")
+    def validate_points_are_ordered(self) -> "Forecast36hV1":
+        """Forecast points must be strictly ordered by timestamp."""
+        if len(self.points) < 2:
+            return self
+        for prev, curr in zip(self.points, self.points[1:]):
+            if curr.timestamp <= prev.timestamp:
+                raise ValueError("points must be strictly ordered by timestamp")
+        return self

--- a/brain/world_model/__init__.py
+++ b/brain/world_model/__init__.py
@@ -4,8 +4,11 @@ from .state_v1_weather_adapter_mapper import (
     WeatherAdapterStateInputV1,
     map_state_v1_to_weather_adapter_input,
 )
+from .weather_client import WeatherClient, normalize_forecast_36h
 
 __all__ = [
     "WeatherAdapterStateInputV1",
     "map_state_v1_to_weather_adapter_input",
+    "WeatherClient",
+    "normalize_forecast_36h",
 ]

--- a/brain/world_model/weather_client.py
+++ b/brain/world_model/weather_client.py
@@ -1,0 +1,128 @@
+"""Weather forecast normalization utilities for Stage 3."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from brain.contracts import Forecast36hV1
+from brain.contracts.forecast_36h_v1 import ForecastPointV1
+
+
+def _parse_datetime(value: Any, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(f"Invalid datetime for {field_name}: {value}") from exc
+    else:
+        raise ValueError(f"Missing or invalid datetime field: {field_name}")
+
+    if dt.tzinfo is None:
+        raise ValueError(f"Datetime field must include timezone: {field_name}")
+    return dt
+
+
+def _pick_float(item: dict[str, Any], keys: list[str], field_name: str) -> float | None:
+    for key in keys:
+        if key in item and item[key] is not None:
+            try:
+                return float(item[key])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid numeric value for {field_name}: {item[key]}") from exc
+    return None
+
+
+def _normalize_row(item: dict[str, Any]) -> ForecastPointV1:
+    timestamp_raw = item.get("timestamp", item.get("ts", item.get("time")))
+    timestamp = _parse_datetime(timestamp_raw, "timestamp")
+
+    ext_temp_c = _pick_float(item, ["ext_temp_c", "temp_c", "temperature_c"], "ext_temp_c")
+    ext_rh_pct = _pick_float(item, ["ext_rh_pct", "rh_pct", "humidity_pct"], "ext_rh_pct")
+    ext_wind_mps = _pick_float(item, ["ext_wind_mps", "wind_mps", "wind_speed_mps"], "ext_wind_mps")
+    ext_cloud_cover_pct = _pick_float(
+        item, ["ext_cloud_cover_pct", "cloud_cover_pct", "cloud_pct"], "ext_cloud_cover_pct"
+    )
+    ext_solar_wm2 = _pick_float(item, ["ext_solar_wm2", "solar_wm2"], "ext_solar_wm2")
+
+    if ext_temp_c is None:
+        raise ValueError("Missing required temperature field for forecast row")
+    if ext_rh_pct is None:
+        raise ValueError("Missing required humidity field for forecast row")
+    if ext_wind_mps is None:
+        raise ValueError("Missing required wind field for forecast row")
+
+    return ForecastPointV1(
+        timestamp=timestamp,
+        ext_temp_c=ext_temp_c,
+        ext_rh_pct=ext_rh_pct,
+        ext_wind_mps=ext_wind_mps,
+        ext_cloud_cover_pct=ext_cloud_cover_pct,
+        ext_solar_wm2=ext_solar_wm2,
+    )
+
+
+def normalize_forecast_36h(
+    raw_payload: list[dict[str, Any]] | dict[str, Any],
+    *,
+    source: str = "weather_stub",
+    timezone_name: str = "Europe/Vienna",
+    freq_minutes: int = 60,
+    horizon_hours: int = 36,
+    generated_at: datetime | None = None,
+) -> Forecast36hV1:
+    """Normalize raw weather payload into strict `forecast_36h_v1` contract."""
+    if freq_minutes <= 0:
+        raise ValueError("freq_minutes must be positive")
+    if horizon_hours <= 0:
+        raise ValueError("horizon_hours must be positive")
+
+    points_input = raw_payload.get("points") if isinstance(raw_payload, dict) else raw_payload
+    if not isinstance(points_input, list) or not points_input:
+        raise ValueError("raw_payload must contain a non-empty list of forecast points")
+
+    normalized_points = [_normalize_row(item) for item in points_input]
+    normalized_points.sort(key=lambda p: p.timestamp)
+
+    max_points = max(1, int((horizon_hours * 60) / freq_minutes))
+    normalized_points = normalized_points[:max_points]
+
+    resolved_generated_at = generated_at or datetime.now(timezone.utc)
+    if resolved_generated_at.tzinfo is None:
+        raise ValueError("generated_at must include timezone info")
+
+    return Forecast36hV1(
+        schema_version="forecast_36h_v1",
+        generated_at=resolved_generated_at,
+        source=source,
+        timezone=timezone_name,
+        freq_minutes=freq_minutes,
+        horizon_hours=min(horizon_hours, 36),
+        points=normalized_points,
+    )
+
+
+class WeatherClient:
+    """Deterministic normalization facade for Stage 3 weather ingestion."""
+
+    def normalize(
+        self,
+        raw_payload: list[dict[str, Any]] | dict[str, Any],
+        *,
+        source: str = "weather_stub",
+        timezone_name: str = "Europe/Vienna",
+        freq_minutes: int = 60,
+        horizon_hours: int = 36,
+        generated_at: datetime | None = None,
+    ) -> Forecast36hV1:
+        return normalize_forecast_36h(
+            raw_payload,
+            source=source,
+            timezone_name=timezone_name,
+            freq_minutes=freq_minutes,
+            horizon_hours=horizon_hours,
+            generated_at=generated_at,
+        )

--- a/tests/contracts/test_forecast_36h_v1.py
+++ b/tests/contracts/test_forecast_36h_v1.py
@@ -1,0 +1,62 @@
+"""Tests for forecast_36h_v1 contract."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts import Forecast36hV1
+from brain.contracts.forecast_36h_v1 import ForecastPointV1
+
+
+def _point(ts: datetime, *, cloud: float | None = 50.0, solar: float | None = None) -> ForecastPointV1:
+    return ForecastPointV1(
+        timestamp=ts,
+        ext_temp_c=12.5,
+        ext_rh_pct=70.0,
+        ext_wind_mps=2.1,
+        ext_cloud_cover_pct=cloud,
+        ext_solar_wm2=solar,
+    )
+
+
+def test_valid_forecast_contract_passes():
+    base = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    forecast = Forecast36hV1(
+        schema_version="forecast_36h_v1",
+        generated_at=base,
+        source="test",
+        timezone="Europe/Vienna",
+        freq_minutes=60,
+        horizon_hours=36,
+        points=[_point(base), _point(base + timedelta(hours=1))],
+    )
+    assert forecast.schema_version == "forecast_36h_v1"
+    assert len(forecast.points) == 2
+
+
+def test_point_requires_cloud_or_solar():
+    base = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValidationError):
+        ForecastPointV1(
+            timestamp=base,
+            ext_temp_c=10.0,
+            ext_rh_pct=70.0,
+            ext_wind_mps=2.0,
+            ext_cloud_cover_pct=None,
+            ext_solar_wm2=None,
+        )
+
+
+def test_forecast_requires_ordered_timestamps():
+    base = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValidationError):
+        Forecast36hV1(
+            schema_version="forecast_36h_v1",
+            generated_at=base,
+            source="test",
+            timezone="Europe/Vienna",
+            freq_minutes=60,
+            horizon_hours=36,
+            points=[_point(base + timedelta(hours=1)), _point(base)],
+        )

--- a/tests/contracts/test_imports.py
+++ b/tests/contracts/test_imports.py
@@ -6,6 +6,7 @@ from brain.contracts import (
     ActionV1,
     AnomalyV1,
     ExecutorEventV1,
+    Forecast36hV1,
     GuardrailResultV1,
     SensorHealthV1,
     StateV1,
@@ -18,5 +19,6 @@ def test_all_contracts_are_importable():
     assert ActionV1 is not None
     assert AnomalyV1 is not None
     assert ExecutorEventV1 is not None
+    assert Forecast36hV1 is not None
     assert GuardrailResultV1 is not None
     assert SensorHealthV1 is not None

--- a/tests/contracts/test_json_schema_export.py
+++ b/tests/contracts/test_json_schema_export.py
@@ -8,6 +8,7 @@ from brain.contracts import (
     ActionV1,
     AnomalyV1,
     ExecutorEventV1,
+    Forecast36hV1,
     GuardrailResultV1,
     SensorHealthV1,
     StateV1,
@@ -26,6 +27,7 @@ class TestJsonSchemaExport:
             SensorHealthV1,
             GuardrailResultV1,
             ExecutorEventV1,
+            Forecast36hV1,
         ]
 
         for contract in contracts:
@@ -71,6 +73,7 @@ class TestJsonSchemaExport:
             SensorHealthV1,
             GuardrailResultV1,
             ExecutorEventV1,
+            Forecast36hV1,
         ]:
             schema = contract.model_json_schema()
             json_str = json.dumps(schema)

--- a/tests/world_model/test_weather_client.py
+++ b/tests/world_model/test_weather_client.py
@@ -1,0 +1,52 @@
+"""Tests for weather forecast normalization client."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.world_model import WeatherClient, normalize_forecast_36h
+
+
+def test_normalization_maps_and_orders_points_deterministically():
+    payload = [
+        {
+            "ts": "2026-02-15T02:00:00+00:00",
+            "temp_c": 8.5,
+            "rh_pct": 80.0,
+            "wind_mps": 1.5,
+            "cloud_cover_pct": 40.0,
+        },
+        {
+            "timestamp": "2026-02-15T01:00:00+00:00",
+            "ext_temp_c": 7.0,
+            "ext_rh_pct": 82.0,
+            "ext_wind_mps": 1.2,
+            "ext_solar_wm2": 15.0,
+        },
+    ]
+    generated_at = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+
+    forecast_a = normalize_forecast_36h(payload, generated_at=generated_at)
+    forecast_b = WeatherClient().normalize(payload, generated_at=generated_at)
+
+    assert forecast_a.model_dump(mode="json") == forecast_b.model_dump(mode="json")
+    assert forecast_a.points[0].timestamp.isoformat() == "2026-02-15T01:00:00+00:00"
+    assert forecast_a.points[1].timestamp.isoformat() == "2026-02-15T02:00:00+00:00"
+
+
+def test_normalization_rejects_missing_required_fields():
+    payload = [
+        {
+            "timestamp": "2026-02-15T01:00:00+00:00",
+            "ext_rh_pct": 82.0,
+            "ext_wind_mps": 1.2,
+            "ext_cloud_cover_pct": 50.0,
+        }
+    ]
+    with pytest.raises(ValueError):
+        normalize_forecast_36h(payload)
+
+
+def test_normalization_rejects_empty_points():
+    with pytest.raises(ValueError):
+        normalize_forecast_36h({"points": []})


### PR DESCRIPTION
## Summary
- add Stage 3 normalized weather forecast contract: `Forecast36hV1` (`forecast_36h_v1`)
- add deterministic weather normalization module: `brain/world_model/weather_client.py`
- add facade API `WeatherClient.normalize(...)` and functional API `normalize_forecast_36h(...)`
- export new contract and world-model normalization utilities
- add required tests for contract and client normalization paths

## Testing
- `pytest -q -o addopts='' tests/world_model/test_weather_client.py tests/contracts/test_forecast_36h_v1.py tests/contracts/test_imports.py tests/contracts/test_json_schema_export.py`
- result: `11 passed`

Closes #53