### PR TITLE
TOMATO-51: add weather adapter baseline contracts and routing

### DIFF
--- a/brain/contracts/__init__.py
+++ b/brain/contracts/__init__.py
@@ -12,8 +12,11 @@ from .executor_event_v1 import ExecutorEventV1
 from .forecast_36h_v1 import Forecast36hV1
 from .guardrail_result_v1 import GuardrailResultV1
 from .observation_v1 import ObservationV1
+from .sampling_plan_v1 import SamplingPlanV1
 from .sensor_health_v1 import SensorHealthV1
 from .state_v1 import StateV1
+from .targets_v1 import TargetsV1
+from .weather_adapter_log_v1 import WeatherAdapterLogV1
 
 __all__ = [
     "StateV1",
@@ -25,4 +28,7 @@ __all__ = [
     "GuardrailResultV1",
     "ExecutorEventV1",
     "Forecast36hV1",
+    "TargetsV1",
+    "SamplingPlanV1",
+    "WeatherAdapterLogV1",
 ]

--- a/brain/contracts/sampling_plan_v1.py
+++ b/brain/contracts/sampling_plan_v1.py
@@ -1,0 +1,52 @@
+"""SamplingPlanV1: weather-adapted sampling cadence plan for Stage 3."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class SamplingOverrideV1(BaseModel):
+    """Time-window override for sampling frequency."""
+
+    model_config = ConfigDict(strict=True)
+
+    start_ts: datetime
+    end_ts: datetime
+    sampling_minutes: int = Field(ge=1, le=180)
+    scenario: str
+    reason: str
+
+    @field_validator("start_ts", "end_ts")
+    @classmethod
+    def validate_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamps must include timezone info")
+        return value
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "SamplingOverrideV1":
+        if self.end_ts <= self.start_ts:
+            raise ValueError("end_ts must be after start_ts")
+        return self
+
+
+class SamplingPlanV1(BaseModel):
+    """Sampling plan emitted by weather adapter for scheduler consumption."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["sampling_plan_v1"]
+    generated_at: datetime
+    base_sampling_minutes: int = Field(ge=1, le=240)
+    active_scenarios: list[str] = Field(default_factory=list)
+    overrides: list[SamplingOverrideV1] = Field(default_factory=list)
+
+    @field_validator("generated_at")
+    @classmethod
+    def validate_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("generated_at must include timezone info")
+        return value

--- a/brain/contracts/targets_v1.py
+++ b/brain/contracts/targets_v1.py
@@ -1,0 +1,63 @@
+"""TargetsV1: weather-adapted target envelope for Stage 3."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class TargetEnvelopeV1(BaseModel):
+    """Environmental and soil target bounds."""
+
+    model_config = ConfigDict(strict=True)
+
+    vpd_min_kpa: float = Field(ge=0.0)
+    vpd_max_kpa: float = Field(ge=0.0)
+    soil_moisture_min_pct: float = Field(ge=0.0, le=100.0)
+    soil_moisture_max_pct: float = Field(ge=0.0, le=100.0)
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "TargetEnvelopeV1":
+        if self.vpd_min_kpa > self.vpd_max_kpa:
+            raise ValueError("vpd_min_kpa must be <= vpd_max_kpa")
+        if self.soil_moisture_min_pct > self.soil_moisture_max_pct:
+            raise ValueError("soil_moisture_min_pct must be <= soil_moisture_max_pct")
+        return self
+
+
+class BudgetAdaptationV1(BaseModel):
+    """Budget multipliers after weather adaptation."""
+
+    model_config = ConfigDict(strict=True)
+
+    water_budget_multiplier: float = Field(ge=0.5, le=2.0)
+    co2_budget_multiplier: float = Field(ge=0.5, le=2.0)
+
+
+class TargetsV1(BaseModel):
+    """World-model output: base and adapted targets with active scenarios."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["targets_v1"]
+    generated_at: datetime
+    valid_until_ts: datetime
+    base_targets: TargetEnvelopeV1
+    adapted_targets: TargetEnvelopeV1
+    adapted_budgets: BudgetAdaptationV1
+    active_scenarios: list[str] = Field(default_factory=list)
+
+    @field_validator("generated_at", "valid_until_ts")
+    @classmethod
+    def validate_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamps must include timezone info")
+        return value
+
+    @model_validator(mode="after")
+    def validate_window(self) -> "TargetsV1":
+        if self.valid_until_ts <= self.generated_at:
+            raise ValueError("valid_until_ts must be after generated_at")
+        return self

--- a/brain/contracts/weather_adapter_log_v1.py
+++ b/brain/contracts/weather_adapter_log_v1.py
@@ -1,0 +1,32 @@
+"""WeatherAdapterLogV1: explainable log for weather adapter decisions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .targets_v1 import TargetEnvelopeV1
+
+
+class WeatherAdapterLogV1(BaseModel):
+    """Traceable log entry for one weather-adapter evaluation cycle."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["weather_adapter_log_v1"]
+    timestamp: datetime
+    forecast_ref: str = Field(min_length=1)
+    state_ref: str = Field(min_length=1)
+    matched_scenarios: list[str] = Field(default_factory=list)
+    applied_changes: list[str] = Field(default_factory=list)
+    guardrail_clips: list[str] = Field(default_factory=list)
+    final_targets: TargetEnvelopeV1
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value

--- a/brain/world_model/__init__.py
+++ b/brain/world_model/__init__.py
@@ -4,11 +4,15 @@ from .state_v1_weather_adapter_mapper import (
     WeatherAdapterStateInputV1,
     map_state_v1_to_weather_adapter_input,
 )
+from .weather_adapter import WeatherAdapter, WeatherAdapterConfig, WeatherAdapterResult
 from .weather_client import WeatherClient, normalize_forecast_36h
 
 __all__ = [
     "WeatherAdapterStateInputV1",
     "map_state_v1_to_weather_adapter_input",
+    "WeatherAdapter",
+    "WeatherAdapterConfig",
+    "WeatherAdapterResult",
     "WeatherClient",
     "normalize_forecast_36h",
 ]

--- a/brain/world_model/weather_adapter.py
+++ b/brain/world_model/weather_adapter.py
@@ -1,0 +1,239 @@
+"""Baseline deterministic weather adapter for Stage 3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from brain.contracts import Forecast36hV1
+from brain.contracts.sampling_plan_v1 import SamplingOverrideV1
+from brain.contracts.targets_v1 import BudgetAdaptationV1, TargetEnvelopeV1, TargetsV1
+from brain.contracts.weather_adapter_log_v1 import WeatherAdapterLogV1
+from brain.contracts import SamplingPlanV1
+from brain.world_model.state_v1_weather_adapter_mapper import WeatherAdapterStateInputV1
+
+SCENARIO_HEATWAVE = "heatwave"
+SCENARIO_DRY_INFLOW = "dry_inflow"
+SCENARIO_WIND_SPIKE = "wind_spike"
+SCENARIO_COLD_SPELL = "cold_spell"
+
+
+@dataclass(frozen=True)
+class WeatherAdapterConfig:
+    """Baseline adapter configuration with deterministic thresholds."""
+
+    base_sampling_minutes: int = 120
+    heatwave_temp_c: float = 32.0
+    dry_inflow_rh_pct: float = 35.0
+    wind_spike_mps: float = 10.0
+    cold_spell_temp_c: float = 8.0
+
+
+@dataclass(frozen=True)
+class WeatherAdapterResult:
+    """Grouped weather-adapter outputs."""
+
+    targets: TargetsV1
+    sampling_plan: SamplingPlanV1
+    log: WeatherAdapterLogV1
+
+
+class WeatherAdapter:
+    """Apply forecast-driven scenario adjustments to targets and cadence."""
+
+    def __init__(self, config: WeatherAdapterConfig | None = None) -> None:
+        self._config = config or WeatherAdapterConfig()
+
+    def apply(
+        self,
+        forecast: Forecast36hV1,
+        state: WeatherAdapterStateInputV1,
+        *,
+        now: datetime | None = None,
+        forecast_ref: str = "forecast_36h_v1",
+        state_ref: str = "state_v1",
+    ) -> WeatherAdapterResult:
+        ts = now or forecast.generated_at
+        scenarios = self._detect_scenarios(forecast)
+
+        base_targets = TargetEnvelopeV1(
+            vpd_min_kpa=0.8,
+            vpd_max_kpa=1.5,
+            soil_moisture_min_pct=35.0,
+            soil_moisture_max_pct=75.0,
+        )
+        adapted_targets, target_changes = self._adapt_targets(base_targets, scenarios)
+        adapted_budgets, budget_changes = self._adapt_budgets(scenarios)
+        sampling_plan, sampling_changes = self._build_sampling_plan(forecast, ts, scenarios)
+
+        targets = TargetsV1(
+            schema_version="targets_v1",
+            generated_at=ts,
+            valid_until_ts=ts + timedelta(hours=forecast.horizon_hours),
+            base_targets=base_targets,
+            adapted_targets=adapted_targets,
+            adapted_budgets=adapted_budgets,
+            active_scenarios=scenarios,
+        )
+
+        log = WeatherAdapterLogV1(
+            schema_version="weather_adapter_log_v1",
+            timestamp=ts,
+            forecast_ref=forecast_ref,
+            state_ref=state_ref,
+            matched_scenarios=scenarios,
+            applied_changes=target_changes + budget_changes + sampling_changes,
+            guardrail_clips=[],
+            final_targets=adapted_targets,
+        )
+
+        return WeatherAdapterResult(targets=targets, sampling_plan=sampling_plan, log=log)
+
+    def _detect_scenarios(self, forecast: Forecast36hV1) -> list[str]:
+        scenarios: list[str] = []
+        if any(point.ext_temp_c >= self._config.heatwave_temp_c for point in forecast.points):
+            scenarios.append(SCENARIO_HEATWAVE)
+        if any(point.ext_rh_pct <= self._config.dry_inflow_rh_pct for point in forecast.points):
+            scenarios.append(SCENARIO_DRY_INFLOW)
+        if any(point.ext_wind_mps >= self._config.wind_spike_mps for point in forecast.points):
+            scenarios.append(SCENARIO_WIND_SPIKE)
+        if any(point.ext_temp_c <= self._config.cold_spell_temp_c for point in forecast.points):
+            scenarios.append(SCENARIO_COLD_SPELL)
+        return scenarios
+
+    def _adapt_targets(
+        self,
+        base: TargetEnvelopeV1,
+        scenarios: list[str],
+    ) -> tuple[TargetEnvelopeV1, list[str]]:
+        changes: list[str] = []
+        vpd_min = base.vpd_min_kpa
+        vpd_max = base.vpd_max_kpa
+        soil_min = base.soil_moisture_min_pct
+        soil_max = base.soil_moisture_max_pct
+
+        if SCENARIO_HEATWAVE in scenarios:
+            vpd_max -= 0.2
+            soil_min += 5.0
+            changes.append("heatwave:lower_vpd_max_raise_soil_min")
+        if SCENARIO_DRY_INFLOW in scenarios:
+            vpd_max -= 0.1
+            soil_min += 3.0
+            changes.append("dry_inflow:lower_vpd_max_raise_soil_min")
+        if SCENARIO_WIND_SPIKE in scenarios:
+            vpd_max -= 0.15
+            changes.append("wind_spike:lower_vpd_max")
+        if SCENARIO_COLD_SPELL in scenarios:
+            vpd_min -= 0.2
+            vpd_max -= 0.2
+            changes.append("cold_spell:shift_vpd_window_lower")
+
+        # Deterministic clipping to safe bounds.
+        vpd_min = max(0.2, min(vpd_min, 2.5))
+        vpd_max = max(vpd_min + 0.1, min(vpd_max, 3.5))
+        soil_min = max(15.0, min(soil_min, 80.0))
+        soil_max = max(soil_min + 5.0, min(soil_max, 95.0))
+
+        return (
+            TargetEnvelopeV1(
+                vpd_min_kpa=round(vpd_min, 3),
+                vpd_max_kpa=round(vpd_max, 3),
+                soil_moisture_min_pct=round(soil_min, 3),
+                soil_moisture_max_pct=round(soil_max, 3),
+            ),
+            changes,
+        )
+
+    def _adapt_budgets(self, scenarios: list[str]) -> tuple[BudgetAdaptationV1, list[str]]:
+        water_multiplier = 1.0
+        co2_multiplier = 1.0
+        changes: list[str] = []
+
+        if SCENARIO_HEATWAVE in scenarios:
+            water_multiplier += 0.3
+            changes.append("heatwave:raise_water_budget")
+        if SCENARIO_DRY_INFLOW in scenarios:
+            water_multiplier += 0.2
+            changes.append("dry_inflow:raise_water_budget")
+        if SCENARIO_COLD_SPELL in scenarios:
+            co2_multiplier -= 0.1
+            changes.append("cold_spell:lower_co2_budget")
+
+        water_multiplier = max(0.5, min(water_multiplier, 2.0))
+        co2_multiplier = max(0.5, min(co2_multiplier, 2.0))
+
+        return (
+            BudgetAdaptationV1(
+                water_budget_multiplier=round(water_multiplier, 3),
+                co2_budget_multiplier=round(co2_multiplier, 3),
+            ),
+            changes,
+        )
+
+    def _build_sampling_plan(
+        self,
+        forecast: Forecast36hV1,
+        now: datetime,
+        scenarios: list[str],
+    ) -> tuple[SamplingPlanV1, list[str]]:
+        overrides: list[SamplingOverrideV1] = []
+        changes: list[str] = []
+
+        scenario_to_minutes = {
+            SCENARIO_HEATWAVE: 15,
+            SCENARIO_DRY_INFLOW: 30,
+            SCENARIO_WIND_SPIKE: 15,
+            SCENARIO_COLD_SPELL: 45,
+        }
+
+        for scenario in scenarios:
+            minutes = scenario_to_minutes[scenario]
+            first_match = next(
+                (
+                    point.timestamp
+                    for point in forecast.points
+                    if self._scenario_matches_point(scenario, point.ext_temp_c, point.ext_rh_pct, point.ext_wind_mps)
+                ),
+                None,
+            )
+            if first_match is None:
+                continue
+            overrides.append(
+                SamplingOverrideV1(
+                    start_ts=first_match,
+                    end_ts=first_match + timedelta(hours=2),
+                    sampling_minutes=minutes,
+                    scenario=scenario,
+                    reason=f"{scenario}:risk_window",
+                )
+            )
+            changes.append(f"{scenario}:sampling_override_{minutes}m")
+
+        overrides.sort(key=lambda item: (item.start_ts, item.scenario))
+        return (
+            SamplingPlanV1(
+                schema_version="sampling_plan_v1",
+                generated_at=now,
+                base_sampling_minutes=self._config.base_sampling_minutes,
+                active_scenarios=scenarios,
+                overrides=overrides,
+            ),
+            changes,
+        )
+
+    def _scenario_matches_point(
+        self,
+        scenario: str,
+        temp_c: float,
+        rh_pct: float,
+        wind_mps: float,
+    ) -> bool:
+        if scenario == SCENARIO_HEATWAVE:
+            return temp_c >= self._config.heatwave_temp_c
+        if scenario == SCENARIO_DRY_INFLOW:
+            return rh_pct <= self._config.dry_inflow_rh_pct
+        if scenario == SCENARIO_WIND_SPIKE:
+            return wind_mps >= self._config.wind_spike_mps
+        if scenario == SCENARIO_COLD_SPELL:
+            return temp_c <= self._config.cold_spell_temp_c
+        return False

--- a/tests/contracts/test_imports.py
+++ b/tests/contracts/test_imports.py
@@ -8,8 +8,11 @@ from brain.contracts import (
     ExecutorEventV1,
     Forecast36hV1,
     GuardrailResultV1,
+    SamplingPlanV1,
     SensorHealthV1,
     StateV1,
+    TargetsV1,
+    WeatherAdapterLogV1,
 )
 
 
@@ -21,4 +24,7 @@ def test_all_contracts_are_importable():
     assert ExecutorEventV1 is not None
     assert Forecast36hV1 is not None
     assert GuardrailResultV1 is not None
+    assert TargetsV1 is not None
+    assert SamplingPlanV1 is not None
+    assert WeatherAdapterLogV1 is not None
     assert SensorHealthV1 is not None

--- a/tests/contracts/test_json_schema_export.py
+++ b/tests/contracts/test_json_schema_export.py
@@ -10,8 +10,11 @@ from brain.contracts import (
     ExecutorEventV1,
     Forecast36hV1,
     GuardrailResultV1,
+    SamplingPlanV1,
     SensorHealthV1,
     StateV1,
+    TargetsV1,
+    WeatherAdapterLogV1,
 )
 
 
@@ -28,6 +31,9 @@ class TestJsonSchemaExport:
             GuardrailResultV1,
             ExecutorEventV1,
             Forecast36hV1,
+            TargetsV1,
+            SamplingPlanV1,
+            WeatherAdapterLogV1,
         ]
 
         for contract in contracts:
@@ -74,6 +80,9 @@ class TestJsonSchemaExport:
             GuardrailResultV1,
             ExecutorEventV1,
             Forecast36hV1,
+            TargetsV1,
+            SamplingPlanV1,
+            WeatherAdapterLogV1,
         ]:
             schema = contract.model_json_schema()
             json_str = json.dumps(schema)

--- a/tests/contracts/test_sampling_plan_v1.py
+++ b/tests/contracts/test_sampling_plan_v1.py
@@ -1,0 +1,40 @@
+"""Tests for sampling_plan_v1 contract."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts.sampling_plan_v1 import SamplingOverrideV1, SamplingPlanV1
+
+
+def test_sampling_plan_valid_payload():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    plan = SamplingPlanV1(
+        schema_version="sampling_plan_v1",
+        generated_at=now,
+        base_sampling_minutes=120,
+        active_scenarios=["heatwave"],
+        overrides=[
+            SamplingOverrideV1(
+                start_ts=now + timedelta(hours=1),
+                end_ts=now + timedelta(hours=3),
+                sampling_minutes=15,
+                scenario="heatwave",
+                reason="risk_window",
+            )
+        ],
+    )
+    assert plan.schema_version == "sampling_plan_v1"
+
+
+def test_sampling_override_rejects_invalid_window():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValidationError):
+        SamplingOverrideV1(
+            start_ts=now + timedelta(hours=1),
+            end_ts=now,
+            sampling_minutes=15,
+            scenario="heatwave",
+            reason="risk_window",
+        )

--- a/tests/contracts/test_targets_v1.py
+++ b/tests/contracts/test_targets_v1.py
@@ -1,0 +1,71 @@
+"""Tests for targets_v1 contract."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts.targets_v1 import BudgetAdaptationV1, TargetEnvelopeV1, TargetsV1
+
+
+def test_targets_v1_valid_payload():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    payload = TargetsV1(
+        schema_version="targets_v1",
+        generated_at=now,
+        valid_until_ts=now + timedelta(hours=6),
+        base_targets=TargetEnvelopeV1(
+            vpd_min_kpa=0.8,
+            vpd_max_kpa=1.5,
+            soil_moisture_min_pct=35.0,
+            soil_moisture_max_pct=75.0,
+        ),
+        adapted_targets=TargetEnvelopeV1(
+            vpd_min_kpa=0.7,
+            vpd_max_kpa=1.3,
+            soil_moisture_min_pct=40.0,
+            soil_moisture_max_pct=75.0,
+        ),
+        adapted_budgets=BudgetAdaptationV1(
+            water_budget_multiplier=1.2,
+            co2_budget_multiplier=0.9,
+        ),
+        active_scenarios=["heatwave"],
+    )
+    assert payload.schema_version == "targets_v1"
+
+
+def test_targets_v1_rejects_invalid_ranges():
+    with pytest.raises(ValidationError):
+        TargetEnvelopeV1(
+            vpd_min_kpa=1.5,
+            vpd_max_kpa=0.8,
+            soil_moisture_min_pct=35.0,
+            soil_moisture_max_pct=75.0,
+        )
+
+
+def test_targets_v1_rejects_invalid_window():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValidationError):
+        TargetsV1(
+            schema_version="targets_v1",
+            generated_at=now,
+            valid_until_ts=now,
+            base_targets=TargetEnvelopeV1(
+                vpd_min_kpa=0.8,
+                vpd_max_kpa=1.5,
+                soil_moisture_min_pct=35.0,
+                soil_moisture_max_pct=75.0,
+            ),
+            adapted_targets=TargetEnvelopeV1(
+                vpd_min_kpa=0.7,
+                vpd_max_kpa=1.3,
+                soil_moisture_min_pct=40.0,
+                soil_moisture_max_pct=75.0,
+            ),
+            adapted_budgets=BudgetAdaptationV1(
+                water_budget_multiplier=1.1,
+                co2_budget_multiplier=1.0,
+            ),
+        )

--- a/tests/contracts/test_weather_adapter_log_v1.py
+++ b/tests/contracts/test_weather_adapter_log_v1.py
@@ -1,0 +1,45 @@
+"""Tests for weather_adapter_log_v1 contract."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from brain.contracts.targets_v1 import TargetEnvelopeV1
+from brain.contracts.weather_adapter_log_v1 import WeatherAdapterLogV1
+
+
+def test_weather_adapter_log_valid_payload():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    log = WeatherAdapterLogV1(
+        schema_version="weather_adapter_log_v1",
+        timestamp=now,
+        forecast_ref="forecast_36h_v1",
+        state_ref="state_v1",
+        matched_scenarios=["heatwave"],
+        applied_changes=["heatwave:lower_vpd_max_raise_soil_min"],
+        guardrail_clips=[],
+        final_targets=TargetEnvelopeV1(
+            vpd_min_kpa=0.8,
+            vpd_max_kpa=1.3,
+            soil_moisture_min_pct=40.0,
+            soil_moisture_max_pct=75.0,
+        ),
+    )
+    assert log.schema_version == "weather_adapter_log_v1"
+
+
+def test_weather_adapter_log_requires_timezone():
+    with pytest.raises(ValidationError):
+        WeatherAdapterLogV1(
+            schema_version="weather_adapter_log_v1",
+            timestamp=datetime(2026, 2, 15, 0, 0),
+            forecast_ref="forecast_36h_v1",
+            state_ref="state_v1",
+            final_targets=TargetEnvelopeV1(
+                vpd_min_kpa=0.8,
+                vpd_max_kpa=1.3,
+                soil_moisture_min_pct=40.0,
+                soil_moisture_max_pct=75.0,
+            ),
+        )

--- a/tests/world_model/test_weather_adapter.py
+++ b/tests/world_model/test_weather_adapter.py
@@ -1,0 +1,122 @@
+"""Tests for Stage 3 weather adapter baseline."""
+
+from datetime import datetime, timedelta, timezone
+
+from brain.contracts import Forecast36hV1, StateV1
+from brain.contracts.forecast_36h_v1 import ForecastPointV1
+from brain.world_model import WeatherAdapter, map_state_v1_to_weather_adapter_input
+
+
+def _forecast(points: list[ForecastPointV1]) -> Forecast36hV1:
+    return Forecast36hV1(
+        schema_version="forecast_36h_v1",
+        generated_at=datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc),
+        source="test",
+        timezone="Europe/Vienna",
+        freq_minutes=60,
+        horizon_hours=36,
+        points=points,
+    )
+
+
+def _state() -> StateV1:
+    return StateV1(
+        schema_version="state_v1",
+        timestamp=datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc),
+        soil_moisture_p1=0.5,
+        soil_moisture_p2=0.52,
+        soil_moisture_avg=0.51,
+        air_temperature=24.0,
+        air_humidity=60.0,
+        vpd=1.2,
+        co2_ppm=420.0,
+        light_intensity=300.0,
+        confidence=0.9,
+    )
+
+
+def test_weather_adapter_routes_high_risk_scenarios_and_overrides():
+    base_ts = datetime(2026, 2, 15, 1, 0, tzinfo=timezone.utc)
+    forecast = _forecast(
+        [
+            ForecastPointV1(
+                timestamp=base_ts,
+                ext_temp_c=33.0,
+                ext_rh_pct=30.0,
+                ext_wind_mps=12.0,
+                ext_cloud_cover_pct=20.0,
+            ),
+            ForecastPointV1(
+                timestamp=base_ts + timedelta(hours=1),
+                ext_temp_c=31.0,
+                ext_rh_pct=40.0,
+                ext_wind_mps=4.0,
+                ext_cloud_cover_pct=30.0,
+            ),
+        ]
+    )
+    adapter = WeatherAdapter()
+    state_input = map_state_v1_to_weather_adapter_input(_state())
+
+    result = adapter.apply(forecast, state_input)
+
+    assert "heatwave" in result.targets.active_scenarios
+    assert "dry_inflow" in result.targets.active_scenarios
+    assert "wind_spike" in result.targets.active_scenarios
+    assert result.sampling_plan.overrides
+    assert result.targets.adapted_targets.vpd_max_kpa < result.targets.base_targets.vpd_max_kpa
+
+
+def test_weather_adapter_noop_window_keeps_base_targets():
+    base_ts = datetime(2026, 2, 15, 1, 0, tzinfo=timezone.utc)
+    forecast = _forecast(
+        [
+            ForecastPointV1(
+                timestamp=base_ts,
+                ext_temp_c=24.0,
+                ext_rh_pct=55.0,
+                ext_wind_mps=3.0,
+                ext_cloud_cover_pct=40.0,
+            ),
+            ForecastPointV1(
+                timestamp=base_ts + timedelta(hours=1),
+                ext_temp_c=23.0,
+                ext_rh_pct=58.0,
+                ext_wind_mps=2.0,
+                ext_cloud_cover_pct=45.0,
+            ),
+        ]
+    )
+    adapter = WeatherAdapter()
+    state_input = map_state_v1_to_weather_adapter_input(_state())
+
+    result = adapter.apply(forecast, state_input)
+
+    assert result.targets.active_scenarios == []
+    assert result.targets.base_targets == result.targets.adapted_targets
+    assert result.sampling_plan.overrides == []
+
+
+def test_weather_adapter_is_deterministic_for_identical_inputs():
+    base_ts = datetime(2026, 2, 15, 1, 0, tzinfo=timezone.utc)
+    forecast = _forecast(
+        [
+            ForecastPointV1(
+                timestamp=base_ts,
+                ext_temp_c=33.0,
+                ext_rh_pct=30.0,
+                ext_wind_mps=12.0,
+                ext_cloud_cover_pct=20.0,
+            )
+        ]
+    )
+    adapter = WeatherAdapter()
+    state_input = map_state_v1_to_weather_adapter_input(_state())
+    now = datetime(2026, 2, 15, 0, 30, tzinfo=timezone.utc)
+
+    a = adapter.apply(forecast, state_input, now=now)
+    b = adapter.apply(forecast, state_input, now=now)
+
+    assert a.targets.model_dump(mode="json") == b.targets.model_dump(mode="json")
+    assert a.sampling_plan.model_dump(mode="json") == b.sampling_plan.model_dump(mode="json")
+    assert a.log.model_dump(mode="json") == b.log.model_dump(mode="json")


### PR DESCRIPTION
## Summary
- add Stage 3 baseline weather adapter with deterministic rule routing from normalized forecast to control targets
- introduce versioned contracts for TargetsV1, SamplingPlanV1, and WeatherAdapterLogV1
- export new contracts/modules and cover normalization + determinism behavior with focused tests

## Testing
- pytest -q -o addopts='' tests\\world_model\\test_weather_adapter.py tests\\contracts\\test_targets_v1.py tests\\contracts\\test_sampling_plan_v1.py tests\\contracts\\test_weather_adapter_log_v1.py tests\\contracts\\test_imports.py tests\\contracts\\test_json_schema_export.py
- result: 15 passed

Closes #54