### PR TITLE
TOMATO-54: add Stage 4 vision contracts and schema exports

### DIFF
--- a/brain/contracts/__init__.py
+++ b/brain/contracts/__init__.py
@@ -16,6 +16,9 @@ from .sampling_plan_v1 import SamplingPlanV1
 from .sensor_health_v1 import SensorHealthV1
 from .state_v1 import StateV1
 from .targets_v1 import TargetsV1
+from .vision_explanation_v1 import VisionExplanationV1
+from .vision_input_v1 import VisionInputV1
+from .vision_v1 import VisionV1
 from .weather_adapter_log_v1 import WeatherAdapterLogV1
 
 __all__ = [
@@ -31,4 +34,7 @@ __all__ = [
     "TargetsV1",
     "SamplingPlanV1",
     "WeatherAdapterLogV1",
+    "VisionInputV1",
+    "VisionV1",
+    "VisionExplanationV1",
 ]

--- a/brain/contracts/vision_explanation_v1.py
+++ b/brain/contracts/vision_explanation_v1.py
@@ -1,0 +1,46 @@
+"""VisionExplanationV1: human-readable explanation for vision output."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VisionExplanationV1(BaseModel):
+    """Explanation payload paired with one VisionV1 result."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["vision_explanation_v1"]
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp of explanation generation.",
+    )
+    image_ref: str = Field(
+        min_length=1,
+        description="Image identifier or path reference.",
+    )
+    vision_ref: str = Field(
+        min_length=1,
+        description="Reference key linking back to the VisionV1 record.",
+    )
+    summary: str = Field(
+        min_length=1,
+        description="Short operator-facing explanation.",
+    )
+    evidence: list[str] = Field(
+        default_factory=list,
+        description="Concrete evidence statements supporting the summary.",
+    )
+    limitations: list[str] = Field(
+        default_factory=list,
+        description="Known limitations for this inference cycle.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value

--- a/brain/contracts/vision_input_v1.py
+++ b/brain/contracts/vision_input_v1.py
@@ -1,0 +1,42 @@
+"""VisionInputV1: deterministic vision analyzer input envelope."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VisionInputV1(BaseModel):
+    """Vision analyzer input metadata for one evaluation cycle."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["vision_input_v1"]
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp for this vision input message.",
+    )
+    image_ref: str = Field(
+        min_length=1,
+        description="Image identifier or path reference.",
+    )
+    state_ref: str = Field(
+        min_length=1,
+        description="Reference to associated StateV1 record.",
+    )
+    telemetry_summary: str = Field(
+        min_length=1,
+        description="Short deterministic telemetry summary for context.",
+    )
+    camera_id: str | None = Field(
+        default=None,
+        description="Optional camera identifier.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value

--- a/brain/contracts/vision_v1.py
+++ b/brain/contracts/vision_v1.py
@@ -1,0 +1,48 @@
+"""VisionV1: structured baseline output from vision analyzer."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VisionV1(BaseModel):
+    """Structured vision assessment for one image/cycle."""
+
+    model_config = ConfigDict(strict=True)
+
+    schema_version: Literal["vision_v1"]
+    timestamp: datetime = Field(
+        description="ISO8601 timestamp for vision assessment.",
+    )
+    image_ref: str = Field(
+        min_length=1,
+        description="Image identifier or path reference.",
+    )
+    source: str = Field(
+        min_length=1,
+        description="Analyzer source name.",
+    )
+    plant_status: Literal["healthy", "watch", "stress", "unknown"]
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Assessment confidence in [0,1].",
+    )
+    findings: list[str] = Field(
+        default_factory=list,
+        description="Detected visual findings.",
+    )
+    stress_signals: list[str] = Field(
+        default_factory=list,
+        description="Subset of findings interpreted as stress signals.",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_has_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include timezone info")
+        return value

--- a/tests/contracts/test_imports.py
+++ b/tests/contracts/test_imports.py
@@ -12,6 +12,9 @@ from brain.contracts import (
     SensorHealthV1,
     StateV1,
     TargetsV1,
+    VisionExplanationV1,
+    VisionInputV1,
+    VisionV1,
     WeatherAdapterLogV1,
 )
 
@@ -27,4 +30,7 @@ def test_all_contracts_are_importable():
     assert TargetsV1 is not None
     assert SamplingPlanV1 is not None
     assert WeatherAdapterLogV1 is not None
+    assert VisionInputV1 is not None
+    assert VisionV1 is not None
+    assert VisionExplanationV1 is not None
     assert SensorHealthV1 is not None

--- a/tests/contracts/test_json_schema_export.py
+++ b/tests/contracts/test_json_schema_export.py
@@ -14,6 +14,9 @@ from brain.contracts import (
     SensorHealthV1,
     StateV1,
     TargetsV1,
+    VisionExplanationV1,
+    VisionInputV1,
+    VisionV1,
     WeatherAdapterLogV1,
 )
 
@@ -34,6 +37,9 @@ class TestJsonSchemaExport:
             TargetsV1,
             SamplingPlanV1,
             WeatherAdapterLogV1,
+            VisionInputV1,
+            VisionV1,
+            VisionExplanationV1,
         ]
 
         for contract in contracts:
@@ -83,6 +89,9 @@ class TestJsonSchemaExport:
             TargetsV1,
             SamplingPlanV1,
             WeatherAdapterLogV1,
+            VisionInputV1,
+            VisionV1,
+            VisionExplanationV1,
         ]:
             schema = contract.model_json_schema()
             json_str = json.dumps(schema)

--- a/tests/contracts/test_vision_explanation_v1.py
+++ b/tests/contracts/test_vision_explanation_v1.py
@@ -1,0 +1,48 @@
+"""Contract tests for VisionExplanationV1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.contracts import VisionExplanationV1
+
+
+def test_vision_explanation_v1_valid_payload():
+    payload = {
+        "schema_version": "vision_explanation_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "sim://frame/0001.jpg",
+        "vision_ref": "vision_v1:run_001:cycle_1",
+        "summary": "Leaf edges show mild upward curl; monitor humidity trend.",
+        "evidence": ["edge curl in upper leaves", "no necrotic spotting"],
+        "limitations": ["single-frame assessment"],
+    }
+    model = VisionExplanationV1.model_validate(payload)
+    assert model.schema_version == "vision_explanation_v1"
+    assert "single-frame assessment" in model.limitations
+
+
+def test_vision_explanation_v1_requires_summary():
+    payload = {
+        "schema_version": "vision_explanation_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "sim://frame/0001.jpg",
+        "vision_ref": "vision_v1:run_001:cycle_1",
+        "summary": "",
+    }
+    with pytest.raises(ValueError):
+        VisionExplanationV1.model_validate(payload)
+
+
+def test_vision_explanation_v1_requires_timezone():
+    payload = {
+        "schema_version": "vision_explanation_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0),
+        "image_ref": "sim://frame/0001.jpg",
+        "vision_ref": "vision_v1:run_001:cycle_1",
+        "summary": "summary",
+    }
+    with pytest.raises(ValueError, match="timezone"):
+        VisionExplanationV1.model_validate(payload)

--- a/tests/contracts/test_vision_input_v1.py
+++ b/tests/contracts/test_vision_input_v1.py
@@ -1,0 +1,47 @@
+"""Contract tests for VisionInputV1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.contracts import VisionInputV1
+
+
+def test_vision_input_v1_valid_payload():
+    payload = {
+        "schema_version": "vision_input_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "sim://frame/0001.jpg",
+        "state_ref": "state_v1:run_001:cycle_1",
+        "telemetry_summary": "vpd=1.28 soil_avg=42.1 confidence=0.91",
+        "camera_id": "cam-front",
+    }
+    model = VisionInputV1.model_validate(payload)
+    assert model.schema_version == "vision_input_v1"
+    assert model.camera_id == "cam-front"
+
+
+def test_vision_input_v1_requires_timezone():
+    payload = {
+        "schema_version": "vision_input_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0),
+        "image_ref": "sim://frame/0001.jpg",
+        "state_ref": "state_v1:run_001:cycle_1",
+        "telemetry_summary": "summary",
+    }
+    with pytest.raises(ValueError, match="timezone"):
+        VisionInputV1.model_validate(payload)
+
+
+def test_vision_input_v1_rejects_empty_refs():
+    payload = {
+        "schema_version": "vision_input_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "",
+        "state_ref": "",
+        "telemetry_summary": "summary",
+    }
+    with pytest.raises(ValueError):
+        VisionInputV1.model_validate(payload)

--- a/tests/contracts/test_vision_v1.py
+++ b/tests/contracts/test_vision_v1.py
@@ -1,0 +1,51 @@
+"""Contract tests for VisionV1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from brain.contracts import VisionV1
+
+
+def test_vision_v1_valid_payload():
+    payload = {
+        "schema_version": "vision_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "sim://frame/0001.jpg",
+        "source": "vision_stub_v1",
+        "plant_status": "watch",
+        "confidence": 0.74,
+        "findings": ["slight_leaf_curl"],
+        "stress_signals": ["leaf_curl"],
+    }
+    model = VisionV1.model_validate(payload)
+    assert model.plant_status == "watch"
+    assert model.confidence == 0.74
+
+
+def test_vision_v1_confidence_bounds():
+    payload = {
+        "schema_version": "vision_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        "image_ref": "sim://frame/0001.jpg",
+        "source": "vision_stub_v1",
+        "plant_status": "healthy",
+        "confidence": 1.1,
+    }
+    with pytest.raises(ValueError):
+        VisionV1.model_validate(payload)
+
+
+def test_vision_v1_requires_timezone():
+    payload = {
+        "schema_version": "vision_v1",
+        "timestamp": datetime(2026, 2, 20, 12, 0),
+        "image_ref": "sim://frame/0001.jpg",
+        "source": "vision_stub_v1",
+        "plant_status": "unknown",
+        "confidence": 0.5,
+    }
+    with pytest.raises(ValueError, match="timezone"):
+        VisionV1.model_validate(payload)


### PR DESCRIPTION
## Summary
- add VisionInputV1, VisionV1, and VisionExplanationV1 contracts under brain/contracts/
- enforce strict typing, timezone-aware timestamps, and core field constraints for Stage 4 vision messages
- export new contracts via brain/contracts/__init__.py
- add dedicated contract tests and extend import/schema-export coverage

## Testing
- python -m pytest -q -o addopts='' tests\\contracts\\test_vision_input_v1.py tests\\contracts\\test_vision_v1.py tests\\contracts\\test_vision_explanation_v1.py tests\\contracts\\test_imports.py tests\\contracts\\test_json_schema_export.py
- result: 14 passed

Closes #60