### PR TITLE
TOMATO-55: add deterministic vision analyzer and runtime wiring

### DIFF
--- a/brain/vision/__init__.py
+++ b/brain/vision/__init__.py
@@ -1,0 +1,5 @@
+"""Vision analyzer components."""
+
+from .baseline_analyzer import BaselineVisionAnalyzer
+
+__all__ = ["BaselineVisionAnalyzer"]

--- a/brain/vision/baseline_analyzer.py
+++ b/brain/vision/baseline_analyzer.py
@@ -1,0 +1,99 @@
+"""Deterministic baseline vision analyzer for Stage 4 simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from brain.contracts import VisionExplanationV1, VisionInputV1, VisionV1
+
+
+@dataclass(frozen=True)
+class BaselineVisionAnalyzer:
+    """Rule-based deterministic analyzer over structured vision input."""
+
+    source_name: str = "vision_baseline_stub_v1"
+
+    def analyze(self, payload: VisionInputV1) -> tuple[VisionV1, VisionExplanationV1]:
+        metrics = _parse_metrics(payload.telemetry_summary)
+        vpd = metrics.get("vpd")
+        soil_avg = metrics.get("soil_avg_pct")
+        confidence_signal = metrics.get("conf")
+
+        findings: list[str] = []
+        stress_signals: list[str] = []
+
+        if vpd is not None and vpd >= 1.6:
+            findings.append("high_vpd_context")
+            stress_signals.append("potential_transpiration_stress")
+        if soil_avg is not None and soil_avg <= 30.0:
+            findings.append("low_soil_moisture_context")
+            stress_signals.append("potential_hydration_stress")
+        if confidence_signal is not None and confidence_signal < 0.5:
+            findings.append("low_telemetry_confidence")
+
+        if confidence_signal is not None and confidence_signal < 0.5:
+            plant_status = "unknown"
+            model_confidence = 0.4
+        elif stress_signals:
+            plant_status = "stress"
+            model_confidence = 0.75
+        elif _is_watch(vpd=vpd, soil_avg=soil_avg):
+            plant_status = "watch"
+            model_confidence = 0.68
+        else:
+            plant_status = "healthy"
+            model_confidence = 0.82
+
+        vision = VisionV1(
+            schema_version="vision_v1",
+            timestamp=payload.timestamp,
+            image_ref=payload.image_ref,
+            source=self.source_name,
+            plant_status=plant_status,
+            confidence=model_confidence,
+            findings=_sorted_unique(findings),
+            stress_signals=_sorted_unique(stress_signals),
+        )
+
+        explanation = VisionExplanationV1(
+            schema_version="vision_explanation_v1",
+            timestamp=payload.timestamp,
+            image_ref=payload.image_ref,
+            vision_ref=f"{vision.schema_version}:{payload.state_ref}",
+            summary=_build_summary(plant_status),
+            evidence=_sorted_unique(findings or ["telemetry_context_nominal"]),
+            limitations=["deterministic_baseline_no_image_pixels"],
+        )
+        return vision, explanation
+
+
+def _parse_metrics(summary: str) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for token in summary.split():
+        if "=" not in token:
+            continue
+        key, raw_value = token.split("=", 1)
+        try:
+            metrics[key] = float(raw_value)
+        except ValueError:
+            continue
+    return metrics
+
+
+def _is_watch(*, vpd: float | None, soil_avg: float | None) -> bool:
+    return (vpd is not None and vpd >= 1.3) or (soil_avg is not None and soil_avg <= 38.0)
+
+
+def _build_summary(plant_status: str) -> str:
+    summaries = {
+        "healthy": "Visual context appears stable in this cycle.",
+        "watch": "Mild visual risk context detected; continue monitoring.",
+        "stress": "Visual risk context indicates potential stress.",
+        "unknown": "Insufficient confidence for a reliable visual assessment.",
+    }
+    return summaries[plant_status]
+
+
+def _sorted_unique(values: Iterable[str]) -> list[str]:
+    return sorted(set(values))

--- a/tests/integration/test_24h_deterministic_run.py
+++ b/tests/integration/test_24h_deterministic_run.py
@@ -17,6 +17,8 @@ from brain.contracts import (
     SensorHealthV1,
     StateV1,
     TargetsV1,
+    VisionExplanationV1,
+    VisionV1,
     WeatherAdapterLogV1,
 )
 
@@ -110,6 +112,10 @@ def test_24h_run_outputs_validate_against_contracts(tmp_path):
         SamplingPlanV1.model_validate(payload, strict=False)
     for payload in _load_jsonl(run_dir / "weather_adapter_log.jsonl"):
         WeatherAdapterLogV1.model_validate(payload, strict=False)
+    for payload in _load_jsonl(run_dir / "vision.jsonl"):
+        VisionV1.model_validate(payload, strict=False)
+    for payload in _load_jsonl(run_dir / "vision_explanations.jsonl"):
+        VisionExplanationV1.model_validate(payload, strict=False)
 
 def test_24h_run_is_deterministic_with_fixed_seed(tmp_path):
     out_a = tmp_path / "a"
@@ -148,6 +154,8 @@ def test_24h_run_jsonl_files_are_readable(tmp_path):
         "targets.jsonl",
         "sampling_plan.jsonl",
         "weather_adapter_log.jsonl",
+        "vision.jsonl",
+        "vision_explanations.jsonl",
     ]:
         path = run_dir / name
         for line in _read_lines(path):
@@ -179,6 +187,8 @@ def test_24h_run_all_artifacts_are_deterministic(tmp_path):
         "targets.jsonl",
         "sampling_plan.jsonl",
         "weather_adapter_log.jsonl",
+        "vision.jsonl",
+        "vision_explanations.jsonl",
     ]:
         left = (run_a / artifact).read_text(encoding="utf-8")
         right = (run_b / artifact).read_text(encoding="utf-8")

--- a/tests/scripts/test_simulate_day_run.py
+++ b/tests/scripts/test_simulate_day_run.py
@@ -51,6 +51,8 @@ def test_generates_state_and_anomaly_logs(tmp_path):
     targets_path = run_dir / "targets.jsonl"
     sampling_plan_path = run_dir / "sampling_plan.jsonl"
     weather_adapter_log_path = run_dir / "weather_adapter_log.jsonl"
+    vision_path = run_dir / "vision.jsonl"
+    vision_explanations_path = run_dir / "vision_explanations.jsonl"
 
     assert state_path.exists()
     assert anomaly_path.exists()
@@ -62,6 +64,8 @@ def test_generates_state_and_anomaly_logs(tmp_path):
     assert targets_path.exists()
     assert sampling_plan_path.exists()
     assert weather_adapter_log_path.exists()
+    assert vision_path.exists()
+    assert vision_explanations_path.exists()
     assert len(_read_lines(state_path)) >= 1
 
     action_records = _load_jsonl(actions_path)
@@ -87,6 +91,10 @@ def test_generates_state_and_anomaly_logs(tmp_path):
         assert record["schema_version"] == "sampling_plan_v1"
     for record in _load_jsonl(weather_adapter_log_path):
         assert record["schema_version"] == "weather_adapter_log_v1"
+    for record in _load_jsonl(vision_path):
+        assert record["schema_version"] == "vision_v1"
+    for record in _load_jsonl(vision_explanations_path):
+        assert record["schema_version"] == "vision_explanation_v1"
 
 def test_time_scale_does_not_change_logical_count(tmp_path):
     out_a = tmp_path / "a"

--- a/tests/vision/test_baseline_analyzer.py
+++ b/tests/vision/test_baseline_analyzer.py
@@ -1,0 +1,44 @@
+"""Tests for deterministic baseline vision analyzer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from brain.contracts import VisionInputV1
+from brain.vision import BaselineVisionAnalyzer
+
+
+def _input(summary: str) -> VisionInputV1:
+    return VisionInputV1(
+        schema_version="vision_input_v1",
+        timestamp=datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc),
+        image_ref="sim://frame/0001.jpg",
+        state_ref="state_v1:run_001:cycle_1",
+        telemetry_summary=summary,
+        camera_id="cam-1",
+    )
+
+
+def test_analyzer_is_deterministic_for_same_input():
+    analyzer = BaselineVisionAnalyzer()
+    payload = _input("vpd=1.22 soil_avg_pct=44.0 conf=0.93")
+    left_vision, left_expl = analyzer.analyze(payload)
+    right_vision, right_expl = analyzer.analyze(payload)
+    assert left_vision.model_dump(mode="json") == right_vision.model_dump(mode="json")
+    assert left_expl.model_dump(mode="json") == right_expl.model_dump(mode="json")
+
+
+def test_analyzer_emits_stress_for_hot_dry_context():
+    analyzer = BaselineVisionAnalyzer()
+    vision, explanation = analyzer.analyze(_input("vpd=1.90 soil_avg_pct=25.0 conf=0.88"))
+    assert vision.plant_status == "stress"
+    assert "potential_hydration_stress" in vision.stress_signals
+    assert explanation.schema_version == "vision_explanation_v1"
+
+
+def test_analyzer_emits_unknown_for_low_confidence_context():
+    analyzer = BaselineVisionAnalyzer()
+    vision, explanation = analyzer.analyze(_input("vpd=1.00 soil_avg_pct=50.0 conf=0.20"))
+    assert vision.plant_status == "unknown"
+    assert vision.confidence == 0.4
+    assert "Insufficient confidence" in explanation.summary


### PR DESCRIPTION
## Summary
- add rain/vision/baseline_analyzer.py with deterministic rule-based analyzer emitting VisionV1 + VisionExplanationV1
- integrate vision analyzer into scripts/simulate_day.py on every cycle
- persist new Stage 4 runtime artifacts: ision.jsonl and ision_explanations.jsonl
- extend script/integration tests to validate contract shape and deterministic artifact behavior

## Testing
- python -m pytest -q -o addopts='' tests\\vision\\test_baseline_analyzer.py tests\\scripts\\test_simulate_day_run.py tests\\integration\\test_24h_deterministic_run.py
- result: 14 passed

Closes #61