### PR TITLE
TOMATO-67: add Codex prompting playbook and templates

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -50,3 +50,4 @@ Current code implements contracts, observation sources, and storage. Estimator, 
 2. `AGENTS.md`
 3. `INSTRUCTIONS.md`
 4. `TECHNICAL_SPECIFICATION.md`
+5. `docs/codex_prompting_playbook.md`

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ The goal is to build an open embodied AI system that the community can inspect a
 - `docs/anomaly_thresholds.md`
 - `docs/error_handling.md`
 - `docs/state_v1_weather_adapter_mapping.md`
+- `docs/codex_prompting_playbook.md`
 
 ---
 

--- a/docs/codex_prompting_playbook.md
+++ b/docs/codex_prompting_playbook.md
@@ -1,0 +1,126 @@
+# Codex Prompting Playbook
+
+This playbook defines how Codex should be prompted and how it should respond in this repository.
+It is aligned with existing repository instructions and does not override higher-priority runtime policies.
+
+---
+
+## Purpose
+
+- Keep implementation output deterministic and execution-focused.
+- Standardize style across planning, coding, testing, and handoff.
+- Reduce prompt drift between contributors.
+
+---
+
+## Priority Rules
+
+- Follow platform/system/developer policies first.
+- Follow repository instructions (`AGENTS.md`, `CODEX.md`, `INSTRUCTIONS.md`) next.
+- Treat this playbook as a reusable operator-facing standard.
+
+If instructions conflict, the higher-priority rule wins.
+
+---
+
+## Core Prompting Standard
+
+- `Mode`: autonomous senior engineer.
+- `Default`: implement working code end-to-end, not only a plan.
+- `Bias`: act on reasonable assumptions unless blocked.
+- `Quality`: correctness, clarity, testability, and deterministic behavior.
+- `Safety`: do not use destructive git/file operations unless explicitly requested.
+- `Communication`: concise progress updates and actionable final summary.
+
+---
+
+## Response Style Rules
+
+- Keep updates short while working; describe concrete next action.
+- Avoid filler and motivational language.
+- Surface assumptions only when they affect behavior or risk.
+- In final response, lead with what changed, then where, then verification.
+- Suggest next steps only when they are natural and actionable.
+
+---
+
+## Ask-vs-Act Boundary
+
+Codex should act without asking when:
+- Scope is clear from issue text and repository context.
+- Reasonable defaults are available.
+- Work can be validated via local tests.
+
+Codex should ask only when:
+- A required secret/credential/external dependency is missing.
+- Requirements are mutually conflicting with no safe default.
+- A destructive action is needed and not explicitly requested.
+
+---
+
+## Reusable Prompt Templates
+
+### 1) Issue Implementation
+
+Use when starting a GitHub issue.
+
+```text
+Implement issue #{N} end-to-end on a feature branch.
+Requirements:
+- Follow repo conventions for branch/commit/PR naming.
+- Make complete working changes, not only a plan.
+- Add or update tests for behavior changes.
+- Run relevant tests and report results.
+- Open a PR that closes the issue.
+```
+
+### 2) PR Creation and Delivery
+
+Use after implementation is complete.
+
+```text
+Push current branch and create a PR.
+PR must include:
+- What changed and why (short bullets)
+- Test command(s) run and pass/fail counts
+- "Closes #{N}" in body
+If branch stacking causes base mismatch, restack onto main cleanly and recreate PR.
+```
+
+### 3) Conflict Resolution
+
+Use when PR reports merge conflicts.
+
+```text
+Resolve PR conflicts without dropping previously merged functionality.
+Steps:
+- Fetch latest main
+- Restack branch cleanly (rebase or cherry-pick on fresh branch)
+- Re-run impacted tests
+- Push and update/recreate PR with same issue linkage
+Report exactly what changed during conflict resolution.
+```
+
+### 4) Review Mode
+
+Use when requesting a code review.
+
+```text
+Review this PR in bug-risk-first order.
+Output format:
+1. Findings by severity with file references
+2. Open questions/assumptions
+3. Brief change summary
+Focus on regressions, safety, determinism, and test gaps.
+```
+
+---
+
+## Final Output Checklist
+
+Before finishing, ensure:
+- Work maps to issue scope and acceptance criteria.
+- Relevant tests are executed or explicit blockers are reported.
+- Branch is pushed and PR is linked (if requested or part of workflow).
+- Summary references changed files and verification outcomes.
+

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -65,6 +65,15 @@ class TestSpecificationDocuments:
         assert "StateV1.soil_moisture_avg * 100" in content
         assert "brain/world_model/state_v1_weather_adapter_mapper.py" in content
 
+    def test_codex_prompting_playbook_exists_and_is_readable(self):
+        """Codex prompting playbook should exist with workflow templates."""
+        doc_path = Path("docs/codex_prompting_playbook.md")
+        assert doc_path.exists(), "docs/codex_prompting_playbook.md not found"
+        content = doc_path.read_text(encoding="utf-8")
+        assert "Codex Prompting Playbook" in content
+        assert "Reusable Prompt Templates" in content
+        assert "Ask-vs-Act Boundary" in content
+
     def test_agents_status_consistency(self):
         """AGENTS status blocks should match implemented Stage 1 components."""
         content = Path("AGENTS.md").read_text(encoding="utf-8")
@@ -102,6 +111,7 @@ class TestSpecificationDocuments:
             Path("docs/anomaly_thresholds.md"),
             Path("docs/error_handling.md"),
             Path("docs/state_v1_weather_adapter_mapping.md"),
+            Path("docs/codex_prompting_playbook.md"),
         ]
 
         for path in docs:


### PR DESCRIPTION
## What changed
- add docs/codex_prompting_playbook.md with standardized prompting rules aligned to existing repo/system constraints
- include explicit ask-vs-act boundary and final output checklist
- add 4 reusable workflow templates: issue implementation, PR delivery, conflict resolution, and review mode
- wire discoverability in CODEX.md and README.md
- add spec guard in 	ests/test_specs.py to ensure playbook presence/readability and include it in mojibake checks

## Validation
- python -m pytest -q -o addopts='' tests\\test_specs.py
- result: 19 passed

Closes #67