### PR TITLE
TOMATO-58: Implement adapter registry and production scaffold driver path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,7 +384,9 @@ Deferred to later stages:
 The current Stage 5 foundation now includes:
 
 - pluggable executor backend selection (`--executor-backend`) in `scripts/simulate_day.py`
+- hardware adapter registry/loader and driver selection (`--hardware-driver`)
 - deterministic hardware adapter abstraction (`brain/executor/hardware_adapter.py`)
+- deterministic production-intended scaffold adapter (`production_scaffold`)
 - deterministic hardware-stub execution path (`brain/executor/hardware_executor.py`)
 
 Deferred to later stages:

--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -52,6 +52,7 @@ This file captures planned components and staged work that are not yet implement
 - Hardware execution foundation started:
   - pluggable executor backend selection in `scripts/simulate_day.py`
   - hardware adapter abstraction in `brain/executor/hardware_adapter.py`
+  - adapter registry/driver selection with deterministic `production_scaffold` adapter
   - deterministic hardware stub executor path in `brain/executor/hardware_executor.py`
 - Stage 5 tracking issues opened:
   - TOMATO-57: Stage 5 tracking - hardware execution reliability and actuator readiness

--- a/README.md
+++ b/README.md
@@ -350,10 +350,12 @@ Scope note:
 Current Stage 5 foundation in `scripts/simulate_day.py` includes:
 
 * Pluggable executor backend selection via `--executor-backend`.
-* Deterministic hardware adapter abstraction (`HardwareStubAdapter`).
+* Hardware adapter registry/loader with driver selection via `--hardware-driver`.
+* Deterministic hardware adapters: `hardware_stub` and `production_scaffold`.
 * Deterministic hardware executor path (`HardwareExecutor`) for validated actions.
 
 Scope note:
 
 * `mock` remains default to preserve prior deterministic behavior.
 * `hardware_stub` is a no-op command routing stub, not a real actuator driver.
+* `production_scaffold` is a production-intended scaffold with explicit TODO boundaries for real actuator transport.

--- a/brain/executor/__init__.py
+++ b/brain/executor/__init__.py
@@ -1,12 +1,25 @@
 """Executor implementations for simulation and hardware dispatch foundations."""
 
-from .hardware_adapter import HardwareDispatchResult, HardwareStubAdapter
+from .hardware_adapter import (
+    HardwareDispatchResult,
+    HardwareStubAdapter,
+    ProductionScaffoldAdapter,
+    available_hardware_adapters,
+    create_hardware_adapter,
+    get_hardware_adapter_factory,
+    register_hardware_adapter,
+)
 from .hardware_executor import HardwareExecutor
 from .mock_executor import MockExecutor
 
 __all__ = [
     "HardwareDispatchResult",
     "HardwareExecutor",
+    "ProductionScaffoldAdapter",
     "HardwareStubAdapter",
     "MockExecutor",
+    "available_hardware_adapters",
+    "create_hardware_adapter",
+    "get_hardware_adapter_factory",
+    "register_hardware_adapter",
 ]

--- a/brain/executor/hardware_adapter.py
+++ b/brain/executor/hardware_adapter.py
@@ -1,10 +1,10 @@
-"""Hardware adapter interface and deterministic stub implementation."""
+"""Hardware adapter interface, registry, and built-in driver implementations."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol
+from typing import Callable, Protocol
 
 from brain.contracts import ActionV1
 from brain.contracts.action_v1 import ActionType
@@ -17,11 +17,24 @@ class HardwareDispatchResult:
     accepted: bool
     command: str
     duration_seconds: float | None
+    adapter_name: str
     details: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.command:
+            raise ValueError("command must be non-empty")
+        if not self.adapter_name:
+            raise ValueError("adapter_name must be non-empty")
+        if self.duration_seconds is not None and self.duration_seconds < 0:
+            raise ValueError("duration_seconds must be >= 0")
 
 
 class HardwareAdapter(Protocol):
     """Abstraction for actuator command dispatch backends."""
+
+    @property
+    def adapter_name(self) -> str:
+        """Stable adapter identity used in logs and observability."""
 
     def dispatch(self, *, action: ActionV1, now: datetime) -> HardwareDispatchResult:
         """Dispatch an action and return deterministic execution metadata."""
@@ -38,11 +51,85 @@ class HardwareStubAdapter:
         ActionType.CIRCULATE.value: "SET_CIRCULATION",
     }
 
+    @property
+    def adapter_name(self) -> str:
+        return "hardware_stub"
+
     def dispatch(self, *, action: ActionV1, now: datetime) -> HardwareDispatchResult:
         command = self._COMMAND_MAP.get(str(action.action_type), "UNKNOWN")
         return HardwareDispatchResult(
             accepted=True,
             command=command,
             duration_seconds=action.duration_seconds,
+            adapter_name=self.adapter_name,
             details=f"hardware_stub_dispatched_at={now.isoformat()}",
         )
+
+
+class ProductionScaffoldAdapter:
+    """
+    Production-intended adapter scaffold.
+
+    TODO(stage-5+): replace deterministic no-op dispatch path with real hardware driver I/O.
+    """
+
+    _COMMAND_MAP = {
+        ActionType.WATER.value: "ACTUATOR_WATER_PULSE",
+        ActionType.LIGHT.value: "ACTUATOR_LIGHT_SET",
+        ActionType.FAN.value: "ACTUATOR_FAN_SET",
+        ActionType.CO2.value: "ACTUATOR_CO2_INJECT",
+        ActionType.CIRCULATE.value: "ACTUATOR_CIRCULATION_SET",
+    }
+
+    @property
+    def adapter_name(self) -> str:
+        return "production_scaffold"
+
+    def dispatch(self, *, action: ActionV1, now: datetime) -> HardwareDispatchResult:
+        command = self._COMMAND_MAP.get(str(action.action_type), "ACTUATOR_UNKNOWN")
+        return HardwareDispatchResult(
+            accepted=True,
+            command=command,
+            duration_seconds=action.duration_seconds,
+            adapter_name=self.adapter_name,
+            details=(
+                "TODO: wire production device transport; "
+                f"scaffold_dispatched_at={now.isoformat()}"
+            ),
+        )
+
+
+HardwareAdapterFactory = Callable[[], HardwareAdapter]
+
+_ADAPTER_FACTORIES: dict[str, HardwareAdapterFactory] = {
+    "hardware_stub": HardwareStubAdapter,
+    "production_scaffold": ProductionScaffoldAdapter,
+}
+
+
+def register_hardware_adapter(name: str, factory: HardwareAdapterFactory) -> None:
+    """Register a hardware adapter factory by stable name."""
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("adapter name must be non-empty")
+    _ADAPTER_FACTORIES[normalized] = factory
+
+
+def available_hardware_adapters() -> tuple[str, ...]:
+    """Return sorted registered adapter names."""
+    return tuple(sorted(_ADAPTER_FACTORIES))
+
+
+def get_hardware_adapter_factory(name: str) -> HardwareAdapterFactory:
+    """Lookup adapter factory by name."""
+    normalized = name.strip().lower()
+    try:
+        return _ADAPTER_FACTORIES[normalized]
+    except KeyError as exc:
+        known = ", ".join(available_hardware_adapters())
+        raise ValueError(f"unknown hardware adapter '{name}'; known: {known}") from exc
+
+
+def create_hardware_adapter(name: str) -> HardwareAdapter:
+    """Create an adapter instance from the registry."""
+    return get_hardware_adapter_factory(name)()

--- a/brain/executor/hardware_executor.py
+++ b/brain/executor/hardware_executor.py
@@ -14,6 +14,8 @@ class HardwareExecutor:
     """Dispatch effective actions through a hardware adapter abstraction."""
 
     def __init__(self, adapter: HardwareAdapter) -> None:
+        if not getattr(adapter, "adapter_name", ""):
+            raise ValueError("adapter must define non-empty adapter_name")
         self._adapter = adapter
 
     def execute(
@@ -46,7 +48,10 @@ class HardwareExecutor:
                 guardrail_decision=guardrail_result.decision,
                 reason_codes=guardrail_result.reason_codes,
                 duration_seconds=None,
-                notes=f"adapter_rejected:{dispatch_result.command}",
+                notes=(
+                    "adapter_rejected:"
+                    f"{dispatch_result.adapter_name}:{dispatch_result.command}"
+                ),
             )
 
         clipped = guardrail_result.decision == GuardrailDecision.CLIPPED.value
@@ -59,8 +64,8 @@ class HardwareExecutor:
             reason_codes=guardrail_result.reason_codes,
             duration_seconds=dispatch_result.duration_seconds,
             notes=(
-                f"executed_hardware_stub_clipped:{dispatch_result.command}"
+                f"executed_{dispatch_result.adapter_name}_clipped:{dispatch_result.command}"
                 if clipped
-                else f"executed_hardware_stub:{dispatch_result.command}"
+                else f"executed_{dispatch_result.adapter_name}:{dispatch_result.command}"
             ),
         )

--- a/tests/executor/test_hardware_adapter.py
+++ b/tests/executor/test_hardware_adapter.py
@@ -2,9 +2,17 @@
 
 from datetime import datetime, timezone
 
+import pytest
+
 from brain.contracts import ActionV1
 from brain.contracts.action_v1 import ActionType
-from brain.executor import HardwareStubAdapter
+from brain.executor import (
+    HardwareDispatchResult,
+    HardwareStubAdapter,
+    available_hardware_adapters,
+    create_hardware_adapter,
+    register_hardware_adapter,
+)
 
 
 def test_dispatch_maps_action_to_expected_command():
@@ -24,3 +32,55 @@ def test_dispatch_maps_action_to_expected_command():
     assert result.accepted is True
     assert result.command == "WATER_PULSE"
     assert result.duration_seconds == 12.0
+    assert result.adapter_name == "hardware_stub"
+
+
+def test_create_adapter_supports_production_scaffold():
+    adapter = create_hardware_adapter("production_scaffold")
+    assert adapter.adapter_name == "production_scaffold"
+
+
+def test_registry_returns_known_adapters():
+    adapters = available_hardware_adapters()
+    assert "hardware_stub" in adapters
+    assert "production_scaffold" in adapters
+
+
+def test_register_hardware_adapter_allows_custom_factory():
+    class _CustomAdapter:
+        @property
+        def adapter_name(self) -> str:
+            return "custom_adapter"
+
+        def dispatch(self, *, action: ActionV1, now: datetime) -> HardwareDispatchResult:
+            return HardwareDispatchResult(
+                accepted=True,
+                command="CUSTOM",
+                duration_seconds=action.duration_seconds,
+                adapter_name=self.adapter_name,
+                details=now.isoformat(),
+            )
+
+    register_hardware_adapter("custom_adapter", _CustomAdapter)
+    adapter = create_hardware_adapter("custom_adapter")
+    assert adapter.adapter_name == "custom_adapter"
+
+
+def test_dispatch_result_validates_required_fields():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    action = ActionV1(
+        schema_version="action_v1",
+        timestamp=now,
+        action_type=ActionType.WATER,
+        duration_seconds=10.0,
+        intensity=0.8,
+        reason="test",
+    )
+    adapter = HardwareStubAdapter()
+    result = adapter.dispatch(action=action, now=now)
+    assert isinstance(result, HardwareDispatchResult)
+
+
+def test_unknown_adapter_name_raises_value_error():
+    with pytest.raises(ValueError):
+        create_hardware_adapter("missing_adapter")

--- a/tests/scripts/test_simulate_day_cli.py
+++ b/tests/scripts/test_simulate_day_cli.py
@@ -24,6 +24,7 @@ def test_help_contains_required_arguments(tmp_path):
         "--time-scale",
         "--scenario",
         "--executor-backend",
+        "--hardware-driver",
         "--verbose",
     ]:
         assert flag in result.stdout
@@ -66,6 +67,29 @@ def test_executor_backend_hardware_stub_is_valid(tmp_path):
             "none",
             "--executor-backend",
             "hardware_stub",
+        ],
+        cwd=Path.cwd(),
+    )
+    assert result.returncode == 0
+
+
+def test_executor_backend_hardware_with_production_scaffold_is_valid(tmp_path):
+    result = _run(
+        [
+            "--seed",
+            "123",
+            "--output-dir",
+            str(tmp_path),
+            "--duration-hours",
+            "2",
+            "--time-scale",
+            "1000000",
+            "--scenario",
+            "none",
+            "--executor-backend",
+            "hardware",
+            "--hardware-driver",
+            "production_scaffold",
         ],
         cwd=Path.cwd(),
     )

--- a/tests/scripts/test_simulate_day_run.py
+++ b/tests/scripts/test_simulate_day_run.py
@@ -148,7 +148,16 @@ def test_fixed_seed_produces_reproducible_outputs(tmp_path):
 def test_event_driven_mode_increases_sampling_frequency(tmp_path):
     result = _run_simulate(
         tmp_path,
-        ["--duration-hours", "8", "--seed", "123", "--time-scale", "1000000", "--scenario", "heatwave"],
+        [
+            "--duration-hours",
+            "8",
+            "--seed",
+            "123",
+            "--time-scale",
+            "1000000",
+            "--scenario",
+            "heatwave",
+        ],
     )
     assert result.returncode == 0
 
@@ -163,3 +172,30 @@ def test_event_driven_mode_increases_sampling_frequency(tmp_path):
     assert "event" in modes
     assert 7200 in intervals
     assert 900 in intervals
+
+
+def test_hardware_backend_uses_selected_driver_in_executor_notes(tmp_path):
+    result = _run_simulate(
+        tmp_path,
+        [
+            "--duration-hours",
+            "2",
+            "--seed",
+            "123",
+            "--time-scale",
+            "1000000",
+            "--executor-backend",
+            "hardware",
+            "--hardware-driver",
+            "production_scaffold",
+        ],
+    )
+    assert result.returncode == 0
+
+    run_dir = _find_run_dir(tmp_path)
+    records = _load_jsonl(run_dir / "executor_log.jsonl")
+    executed = [record for record in records if record["status"] == "executed"]
+    assert all(
+        record["notes"].startswith("executed_production_scaffold:")
+        for record in executed
+    )


### PR DESCRIPTION
## Summary
- add hardware adapter registry/loader APIs and strict dispatch-result validation
- add production-intended production_scaffold adapter with explicit TODO boundary for real transport wiring
- wire scripts/simulate_day.py to support --executor-backend hardware + --hardware-driver
- keep backward-compatible deterministic paths for mock and hardware_stub
- update Stage 5 docs in README/AGENTS/PLANNED_FEATURES
- add test coverage for registry, executor notes, and CLI/run driver selection

## Testing
- pytest -q --no-cov tests/executor/test_hardware_adapter.py tests/executor/test_hardware_executor.py tests/scripts/test_simulate_day_cli.py tests/scripts/test_simulate_day_run.py
- result: 19 passed

Closes #70