### PR TITLE
TOMATO-59: Add executor state machine and transition event logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,9 +388,10 @@ The current Stage 5 foundation now includes:
 - deterministic hardware adapter abstraction (`brain/executor/hardware_adapter.py`)
 - deterministic production-intended scaffold adapter (`production_scaffold`)
 - deterministic hardware-stub execution path (`brain/executor/hardware_executor.py`)
+- deterministic executor state machine transitions (`nominal`, `degraded`, `faulted`, `safe_mode`)
+- persisted state transition events in `executor_log.jsonl`
 
 Deferred to later stages:
 
 - production hardware actuator drivers
-- device state machine and fault recovery policy
 - execution retries, idempotency keys, and telemetry acks

--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -54,6 +54,7 @@ This file captures planned components and staged work that are not yet implement
   - hardware adapter abstraction in `brain/executor/hardware_adapter.py`
   - adapter registry/driver selection with deterministic `production_scaffold` adapter
   - deterministic hardware stub executor path in `brain/executor/hardware_executor.py`
+  - deterministic executor runtime state machine in `brain/executor/hardware_state_machine.py`
 - Stage 5 tracking issues opened:
   - TOMATO-57: Stage 5 tracking - hardware execution reliability and actuator readiness
   - TOMATO-58: Implement production-ready hardware actuator adapter boundary and driver selection
@@ -63,7 +64,6 @@ This file captures planned components and staged work that are not yet implement
   - TOMATO-62: Integrate Stage 5 artifacts into fixtures, deterministic tests, and docs alignment
 - Remaining Stage 5 expansion:
   - production hardware adapter for actuator I/O
-  - device state machine with fault and safe-mode transitions
   - retry/backoff strategy and execution idempotency keys
 
 ---

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Current Stage 5 foundation in `scripts/simulate_day.py` includes:
 * Hardware adapter registry/loader with driver selection via `--hardware-driver`.
 * Deterministic hardware adapters: `hardware_stub` and `production_scaffold`.
 * Deterministic hardware executor path (`HardwareExecutor`) for validated actions.
+* Deterministic executor runtime state machine (`nominal`, `degraded`, `faulted`, `safe_mode`) with transition events in `executor_log.jsonl`.
 
 Scope note:
 

--- a/brain/executor/__init__.py
+++ b/brain/executor/__init__.py
@@ -10,12 +10,22 @@ from .hardware_adapter import (
     register_hardware_adapter,
 )
 from .hardware_executor import HardwareExecutor
+from .hardware_state_machine import (
+    ExecutorRuntimeState,
+    HardwareExecutionStateMachine,
+    StateMachineConfig,
+    StateTransition,
+)
 from .mock_executor import MockExecutor
 
 __all__ = [
     "HardwareDispatchResult",
     "HardwareExecutor",
+    "ExecutorRuntimeState",
+    "HardwareExecutionStateMachine",
     "ProductionScaffoldAdapter",
+    "StateMachineConfig",
+    "StateTransition",
     "HardwareStubAdapter",
     "MockExecutor",
     "available_hardware_adapters",

--- a/brain/executor/hardware_executor.py
+++ b/brain/executor/hardware_executor.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from brain.contracts import ActionV1, ExecutorEventV1, GuardrailResultV1
+from brain.contracts import ActionV1, DeviceStatusV1, ExecutorEventV1, GuardrailResultV1
 from brain.contracts.executor_event_v1 import ExecutorStatus
 from brain.contracts.guardrail_result_v1 import GuardrailDecision
 from brain.executor.hardware_adapter import HardwareAdapter
+from brain.executor.hardware_state_machine import (
+    HardwareExecutionStateMachine,
+    StateTransition,
+)
 
 
 class HardwareExecutor:
@@ -17,6 +21,40 @@ class HardwareExecutor:
         if not getattr(adapter, "adapter_name", ""):
             raise ValueError("adapter must define non-empty adapter_name")
         self._adapter = adapter
+        self._state_machine = HardwareExecutionStateMachine()
+        self._pending_runtime_events: list[ExecutorEventV1] = []
+
+    def drain_runtime_events(self) -> list[ExecutorEventV1]:
+        """Return and clear queued state-machine runtime events."""
+        drained = self._pending_runtime_events[:]
+        self._pending_runtime_events.clear()
+        return drained
+
+    def _queue_transition_events(
+        self,
+        *,
+        transitions: list[StateTransition],
+        action_type: str,
+        guardrail_decision: str,
+        reason_codes: list[str],
+    ) -> None:
+        for transition in transitions:
+            self._pending_runtime_events.append(
+                ExecutorEventV1(
+                    schema_version="executor_event_v1",
+                    timestamp=transition.timestamp,
+                    status=ExecutorStatus.SKIPPED,
+                    action_type=action_type,
+                    guardrail_decision=guardrail_decision,
+                    reason_codes=reason_codes,
+                    duration_seconds=None,
+                    notes=(
+                        "state_transition:"
+                        f"{transition.previous_state.value}"
+                        f"->{transition.next_state.value}:{transition.reason}"
+                    ),
+                )
+            )
 
     def execute(
         self,
@@ -25,7 +63,31 @@ class HardwareExecutor:
         effective_action: ActionV1 | None,
         guardrail_result: GuardrailResultV1,
         now: datetime,
+        device_status: DeviceStatusV1 | None = None,
     ) -> ExecutorEventV1:
+        pre_dispatch_transitions = self._state_machine.observe_telemetry(
+            now=now,
+            device_status=device_status,
+        )
+        self._queue_transition_events(
+            transitions=pre_dispatch_transitions,
+            action_type=str(proposed_action.action_type),
+            guardrail_decision=guardrail_result.decision,
+            reason_codes=guardrail_result.reason_codes,
+        )
+
+        if not self._state_machine.can_execute():
+            return ExecutorEventV1(
+                schema_version="executor_event_v1",
+                timestamp=now,
+                status=ExecutorStatus.SKIPPED,
+                action_type=str(proposed_action.action_type),
+                guardrail_decision=guardrail_result.decision,
+                reason_codes=guardrail_result.reason_codes,
+                duration_seconds=None,
+                notes=f"blocked_by_state:{self._state_machine.state.value}",
+            )
+
         if effective_action is None:
             return ExecutorEventV1(
                 schema_version="executor_event_v1",
@@ -39,6 +101,17 @@ class HardwareExecutor:
             )
 
         dispatch_result = self._adapter.dispatch(action=effective_action, now=now)
+        post_dispatch_transitions = self._state_machine.observe_dispatch_result(
+            accepted=dispatch_result.accepted,
+            now=now,
+        )
+        self._queue_transition_events(
+            transitions=post_dispatch_transitions,
+            action_type=str(effective_action.action_type),
+            guardrail_decision=guardrail_result.decision,
+            reason_codes=guardrail_result.reason_codes,
+        )
+
         if not dispatch_result.accepted:
             return ExecutorEventV1(
                 schema_version="executor_event_v1",

--- a/brain/executor/hardware_state_machine.py
+++ b/brain/executor/hardware_state_machine.py
@@ -1,0 +1,197 @@
+"""Deterministic runtime state machine for hardware execution lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from brain.contracts import DeviceStatusV1
+
+
+class ExecutorRuntimeState(str, Enum):
+    """Executor runtime states for hardware dispatch lifecycle."""
+
+    NOMINAL = "nominal"
+    DEGRADED = "degraded"
+    FAULTED = "faulted"
+    SAFE_MODE = "safe_mode"
+
+
+@dataclass(frozen=True)
+class StateTransition:
+    """Single state transition event."""
+
+    previous_state: ExecutorRuntimeState
+    next_state: ExecutorRuntimeState
+    reason: str
+    timestamp: datetime
+
+
+@dataclass(frozen=True)
+class StateMachineConfig:
+    """Thresholds for deterministic state transitions."""
+
+    stale_after_seconds: int = 15 * 60
+    fault_after_seconds: int = 45 * 60
+    adapter_errors_for_fault: int = 2
+    adapter_errors_for_safe_mode: int = 3
+    healthy_cycles_for_recovery: int = 2
+
+
+class HardwareExecutionStateMachine:
+    """Tracks runtime health state from telemetry and dispatch outcomes."""
+
+    def __init__(self, config: StateMachineConfig | None = None) -> None:
+        self._config = config or StateMachineConfig()
+        self._state = ExecutorRuntimeState.NOMINAL
+        self._consecutive_adapter_errors = 0
+        self._consecutive_healthy_cycles = 0
+
+    @property
+    def state(self) -> ExecutorRuntimeState:
+        return self._state
+
+    def can_execute(self) -> bool:
+        return self._state in {
+            ExecutorRuntimeState.NOMINAL,
+            ExecutorRuntimeState.DEGRADED,
+        }
+
+    def observe_telemetry(
+        self,
+        *,
+        now: datetime,
+        device_status: DeviceStatusV1 | None,
+    ) -> list[StateTransition]:
+        transitions: list[StateTransition] = []
+        if device_status is None:
+            self._consecutive_healthy_cycles = 0
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.FAULTED,
+                    reason="telemetry_missing",
+                    timestamp=now,
+                )
+            )
+            return transitions
+
+        age_seconds = max(0.0, (now - device_status.timestamp).total_seconds())
+        telemetry_fault = (not device_status.mcu_connected) or (
+            age_seconds > self._config.fault_after_seconds
+        )
+        telemetry_degraded = age_seconds > self._config.stale_after_seconds
+
+        if telemetry_fault:
+            self._consecutive_healthy_cycles = 0
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.FAULTED,
+                    reason=(
+                        "mcu_disconnected"
+                        if not device_status.mcu_connected
+                        else "telemetry_stale_fault"
+                    ),
+                    timestamp=now,
+                )
+            )
+            return transitions
+
+        if telemetry_degraded:
+            self._consecutive_healthy_cycles = 0
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.DEGRADED,
+                    reason="telemetry_stale_degraded",
+                    timestamp=now,
+                )
+            )
+            return transitions
+
+        self._consecutive_healthy_cycles += 1
+        if (
+            self._state == ExecutorRuntimeState.SAFE_MODE
+            and self._consecutive_adapter_errors == 0
+            and self._consecutive_healthy_cycles >= self._config.healthy_cycles_for_recovery
+        ):
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.DEGRADED,
+                    reason="safe_mode_recovery_window",
+                    timestamp=now,
+                )
+            )
+            return transitions
+
+        if (
+            self._state in {ExecutorRuntimeState.DEGRADED, ExecutorRuntimeState.FAULTED}
+            and self._consecutive_adapter_errors == 0
+            and self._consecutive_healthy_cycles >= self._config.healthy_cycles_for_recovery
+        ):
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.NOMINAL,
+                    reason="telemetry_recovered",
+                    timestamp=now,
+                )
+            )
+        return transitions
+
+    def observe_dispatch_result(
+        self,
+        *,
+        accepted: bool,
+        now: datetime,
+    ) -> list[StateTransition]:
+        transitions: list[StateTransition] = []
+        if accepted:
+            self._consecutive_adapter_errors = 0
+            return transitions
+
+        self._consecutive_adapter_errors += 1
+        self._consecutive_healthy_cycles = 0
+        if self._consecutive_adapter_errors >= self._config.adapter_errors_for_safe_mode:
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.SAFE_MODE,
+                    reason="adapter_errors_safe_mode",
+                    timestamp=now,
+                )
+            )
+        elif self._consecutive_adapter_errors >= self._config.adapter_errors_for_fault:
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.FAULTED,
+                    reason="adapter_errors_faulted",
+                    timestamp=now,
+                )
+            )
+        else:
+            transitions.extend(
+                self._transition_to(
+                    ExecutorRuntimeState.DEGRADED,
+                    reason="adapter_error_degraded",
+                    timestamp=now,
+                )
+            )
+        return transitions
+
+    def _transition_to(
+        self,
+        next_state: ExecutorRuntimeState,
+        *,
+        reason: str,
+        timestamp: datetime,
+    ) -> list[StateTransition]:
+        if self._state == next_state:
+            return []
+        previous_state = self._state
+        self._state = next_state
+        return [
+            StateTransition(
+                previous_state=previous_state,
+                next_state=next_state,
+                reason=reason,
+                timestamp=timestamp,
+            )
+        ]

--- a/brain/executor/mock_executor.py
+++ b/brain/executor/mock_executor.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from brain.contracts import ActionV1, ExecutorEventV1, GuardrailResultV1
+from brain.contracts import ActionV1, DeviceStatusV1, ExecutorEventV1, GuardrailResultV1
 from brain.contracts.executor_event_v1 import ExecutorStatus
 from brain.contracts.guardrail_result_v1 import GuardrailDecision
 
 
 class MockExecutor:
     """Record execution intent without affecting plant dynamics."""
+
+    def drain_runtime_events(self) -> list[ExecutorEventV1]:
+        """Mock executor emits no out-of-band runtime events."""
+        return []
 
     def execute(
         self,
@@ -19,6 +23,7 @@ class MockExecutor:
         effective_action: ActionV1 | None,
         guardrail_result: GuardrailResultV1,
         now: datetime,
+        device_status: DeviceStatusV1 | None = None,
     ) -> ExecutorEventV1:
         """Return execution event from proposal/guardrail outcome."""
         if effective_action is None:

--- a/scripts/simulate_day.py
+++ b/scripts/simulate_day.py
@@ -362,7 +362,10 @@ def run_simulation(args: argparse.Namespace) -> Path:
                 effective_action=effective_action,
                 guardrail_result=guardrail_result,
                 now=now,
+                device_status=device_status,
             )
+            for runtime_event in executor.drain_runtime_events():
+                executor_log_writer.append(runtime_event.model_dump(mode="json"))
             executor_log_writer.append(executor_event.model_dump(mode="json"))
             if effective_action is not None:
                 actions_writer.append(effective_action.model_dump(mode="json"))

--- a/tests/executor/test_hardware_state_machine.py
+++ b/tests/executor/test_hardware_state_machine.py
@@ -1,0 +1,117 @@
+"""Tests for hardware execution runtime state machine."""
+
+from datetime import datetime, timedelta, timezone
+
+from brain.contracts import DeviceStatusV1
+from brain.executor import (
+    ExecutorRuntimeState,
+    HardwareExecutionStateMachine,
+    StateMachineConfig,
+)
+
+
+def _device_status(ts: datetime, *, connected: bool = True) -> DeviceStatusV1:
+    return DeviceStatusV1(
+        schema_version="device_status_v1",
+        timestamp=ts,
+        light_on=False,
+        fans_on=True,
+        heater_on=False,
+        pump_on=False,
+        co2_on=False,
+        mcu_connected=connected,
+        mcu_uptime_seconds=1000,
+        mcu_reset_count=0,
+    )
+
+
+def test_telemetry_stale_degrades_state():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    machine = HardwareExecutionStateMachine()
+    stale = _device_status(now - timedelta(minutes=20))
+
+    transitions = machine.observe_telemetry(now=now, device_status=stale)
+
+    assert machine.state == ExecutorRuntimeState.DEGRADED
+    assert len(transitions) == 1
+    assert transitions[0].reason == "telemetry_stale_degraded"
+
+
+def test_disconnected_mcu_faults_state():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    machine = HardwareExecutionStateMachine()
+
+    transitions = machine.observe_telemetry(
+        now=now,
+        device_status=_device_status(now, connected=False),
+    )
+
+    assert machine.state == ExecutorRuntimeState.FAULTED
+    assert transitions[0].reason == "mcu_disconnected"
+    assert machine.can_execute() is False
+
+
+def test_adapter_errors_enter_safe_mode():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    machine = HardwareExecutionStateMachine()
+
+    machine.observe_dispatch_result(accepted=False, now=now)
+    machine.observe_dispatch_result(accepted=False, now=now + timedelta(seconds=1))
+    transitions = machine.observe_dispatch_result(
+        accepted=False,
+        now=now + timedelta(seconds=2),
+    )
+
+    assert machine.state == ExecutorRuntimeState.SAFE_MODE
+    assert transitions[0].reason == "adapter_errors_safe_mode"
+    assert machine.can_execute() is False
+
+
+def test_recovery_to_nominal_after_healthy_cycles():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    config = StateMachineConfig(healthy_cycles_for_recovery=2)
+    machine = HardwareExecutionStateMachine(config=config)
+    machine.observe_telemetry(
+        now=now,
+        device_status=_device_status(now - timedelta(minutes=20)),
+    )
+    assert machine.state == ExecutorRuntimeState.DEGRADED
+
+    machine.observe_dispatch_result(accepted=True, now=now + timedelta(minutes=1))
+    first = machine.observe_telemetry(
+        now=now + timedelta(minutes=1),
+        device_status=_device_status(now + timedelta(minutes=1)),
+    )
+    second = machine.observe_telemetry(
+        now=now + timedelta(minutes=2),
+        device_status=_device_status(now + timedelta(minutes=2)),
+    )
+
+    assert first == []
+    assert machine.state == ExecutorRuntimeState.NOMINAL
+    assert len(second) == 1
+    assert second[0].reason == "telemetry_recovered"
+
+
+def test_safe_mode_recovers_to_degraded_after_healthy_window():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    config = StateMachineConfig(healthy_cycles_for_recovery=2)
+    machine = HardwareExecutionStateMachine(config=config)
+    machine.observe_dispatch_result(accepted=False, now=now)
+    machine.observe_dispatch_result(accepted=False, now=now + timedelta(seconds=1))
+    machine.observe_dispatch_result(accepted=False, now=now + timedelta(seconds=2))
+    assert machine.state == ExecutorRuntimeState.SAFE_MODE
+
+    machine.observe_dispatch_result(accepted=True, now=now + timedelta(seconds=3))
+    machine.observe_telemetry(
+        now=now + timedelta(minutes=1),
+        device_status=_device_status(now + timedelta(minutes=1)),
+    )
+    transitions = machine.observe_telemetry(
+        now=now + timedelta(minutes=2),
+        device_status=_device_status(now + timedelta(minutes=2)),
+    )
+
+    assert machine.state == ExecutorRuntimeState.DEGRADED
+    assert len(transitions) == 1
+    assert transitions[0].reason == "safe_mode_recovery_window"


### PR DESCRIPTION
## Summary
- add deterministic hardware execution state machine (
ominal, degraded, aulted, safe_mode)
- add telemetry-driven and adapter-error-driven transition rules with recovery windows
- integrate state checks into HardwareExecutor so faulted/safe-mode paths block unsafe execution
- persist runtime state transitions as ExecutorEventV1 entries in executor_log.jsonl
- wire runtime-event draining into scripts/simulate_day.py
- update Stage 5 docs in README.md, AGENTS.md, and PLANNED_FEATURES.md

## Testing
- pytest -q --no-cov tests/executor/test_hardware_executor.py tests/executor/test_hardware_state_machine.py tests/integration/test_24h_deterministic_run.py
- result: 18 passed

Closes #71