### PR TITLE
TOMATO-61: Add idempotency-key deduplication in executor flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,8 +392,10 @@ The current Stage 5 foundation now includes:
 - persisted state transition events in `executor_log.jsonl`
 - deterministic retry/backoff policy for retryable adapter failures
 - persisted retry scheduling events in `executor_log.jsonl`
+- deterministic idempotency-key deduplication in hardware executor flow
+- persisted idempotency tracking events in `executor_log.jsonl`
 
 Deferred to later stages:
 
 - production hardware actuator drivers
-- idempotency keys and telemetry acks
+- telemetry acks

--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -56,6 +56,7 @@ This file captures planned components and staged work that are not yet implement
   - deterministic hardware stub executor path in `brain/executor/hardware_executor.py`
   - deterministic executor runtime state machine in `brain/executor/hardware_state_machine.py`
   - deterministic retry/backoff policy in `brain/executor/retry_policy.py`
+  - deterministic idempotency-key deduplication in `brain/executor/hardware_executor.py`
 - Stage 5 tracking issues opened:
   - TOMATO-57: Stage 5 tracking - hardware execution reliability and actuator readiness
   - TOMATO-58: Implement production-ready hardware actuator adapter boundary and driver selection
@@ -65,7 +66,6 @@ This file captures planned components and staged work that are not yet implement
   - TOMATO-62: Integrate Stage 5 artifacts into fixtures, deterministic tests, and docs alignment
 - Remaining Stage 5 expansion:
   - production hardware adapter for actuator I/O
-  - execution idempotency keys
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Current Stage 5 foundation in `scripts/simulate_day.py` includes:
 * Deterministic hardware executor path (`HardwareExecutor`) for validated actions.
 * Deterministic executor runtime state machine (`nominal`, `degraded`, `faulted`, `safe_mode`) with transition events in `executor_log.jsonl`.
 * Deterministic retry/backoff policy for retryable adapter failures with retry scheduling events in `executor_log.jsonl`.
+* Deterministic idempotency-key deduplication and duplicate-dispatch skip events in `executor_log.jsonl`.
 
 Scope note:
 

--- a/brain/contracts/action_v1.py
+++ b/brain/contracts/action_v1.py
@@ -102,6 +102,15 @@ class ActionV1(BaseModel):
         default=None,
         description="Optional notes or warnings about this action.",
     )
+    idempotency_key: Optional[str] = Field(
+        default=None,
+        min_length=8,
+        max_length=128,
+        description=(
+            "Optional deduplication key for execution requests. "
+            "Repeated dispatch with the same key can be safely skipped."
+        ),
+    )
 
     @field_validator("timestamp")
     @classmethod

--- a/brain/executor/__init__.py
+++ b/brain/executor/__init__.py
@@ -17,6 +17,7 @@ from .hardware_state_machine import (
     StateMachineConfig,
     StateTransition,
 )
+from .idempotency import IdempotencyConfig
 from .mock_executor import MockExecutor
 from .retry_policy import RetryPolicyConfig
 
@@ -31,6 +32,7 @@ __all__ = [
     "StateTransition",
     "HardwareStubAdapter",
     "MockExecutor",
+    "IdempotencyConfig",
     "available_hardware_adapters",
     "create_hardware_adapter",
     "get_hardware_adapter_factory",

--- a/brain/executor/hardware_executor.py
+++ b/brain/executor/hardware_executor.py
@@ -1,7 +1,8 @@
-"""Executor that routes validated actions through a hardware adapter."""
+"""Executor that routes validated actions through hardware adapters."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from brain.contracts import ActionV1, DeviceStatusV1, ExecutorEventV1, GuardrailResultV1
@@ -12,7 +13,15 @@ from brain.executor.hardware_state_machine import (
     HardwareExecutionStateMachine,
     StateTransition,
 )
+from brain.executor.idempotency import IdempotencyConfig
 from brain.executor.retry_policy import RetryPolicyConfig
+
+
+@dataclass(frozen=True)
+class _IdempotencyEntry:
+    key: str
+    first_seen_at: datetime
+    expires_at: datetime
 
 
 class HardwareExecutor:
@@ -23,16 +32,19 @@ class HardwareExecutor:
         adapter: HardwareAdapter,
         *,
         retry_policy: RetryPolicyConfig | None = None,
+        idempotency: IdempotencyConfig | None = None,
     ) -> None:
         if not getattr(adapter, "adapter_name", ""):
             raise ValueError("adapter must define non-empty adapter_name")
         self._adapter = adapter
         self._retry_policy = retry_policy or RetryPolicyConfig()
+        self._idempotency = idempotency or IdempotencyConfig()
         self._state_machine = HardwareExecutionStateMachine()
         self._pending_runtime_events: list[ExecutorEventV1] = []
+        self._idempotency_cache: dict[str, _IdempotencyEntry] = {}
 
     def drain_runtime_events(self) -> list[ExecutorEventV1]:
-        """Return and clear queued state-machine runtime events."""
+        """Return and clear queued state-machine/runtime events."""
         drained = self._pending_runtime_events[:]
         self._pending_runtime_events.clear()
         return drained
@@ -62,6 +74,33 @@ class HardwareExecutor:
                     ),
                 )
             )
+
+    def _append_runtime_event(
+        self,
+        *,
+        timestamp: datetime,
+        action_type: str,
+        guardrail_decision: str,
+        reason_codes: list[str],
+        note: str,
+    ) -> None:
+        self._pending_runtime_events.append(
+            ExecutorEventV1(
+                schema_version="executor_event_v1",
+                timestamp=timestamp,
+                status=ExecutorStatus.SKIPPED,
+                action_type=action_type,
+                guardrail_decision=guardrail_decision,
+                reason_codes=reason_codes,
+                duration_seconds=None,
+                notes=note,
+            )
+        )
+
+    def _purge_expired_idempotency(self, *, now: datetime) -> None:
+        expired = [key for key, entry in self._idempotency_cache.items() if entry.expires_at <= now]
+        for key in expired:
+            self._idempotency_cache.pop(key, None)
 
     def execute(
         self,
@@ -105,6 +144,33 @@ class HardwareExecutor:
                 reason_codes=guardrail_result.reason_codes,
                 duration_seconds=None,
                 notes="skipped_by_guardrails_v1",
+            )
+
+        key = effective_action.idempotency_key or proposed_action.idempotency_key
+        self._purge_expired_idempotency(now=now)
+        if key is not None and key in self._idempotency_cache:
+            cached = self._idempotency_cache[key]
+            self._append_runtime_event(
+                timestamp=now,
+                action_type=str(effective_action.action_type),
+                guardrail_decision=guardrail_result.decision,
+                reason_codes=guardrail_result.reason_codes,
+                note=(
+                    "idempotency_hit:"
+                    f"key={cached.key}:"
+                    f"first_seen_at={cached.first_seen_at.isoformat()}:"
+                    f"expires_at={cached.expires_at.isoformat()}"
+                ),
+            )
+            return ExecutorEventV1(
+                schema_version="executor_event_v1",
+                timestamp=now,
+                status=ExecutorStatus.SKIPPED,
+                action_type=str(effective_action.action_type),
+                guardrail_decision=guardrail_result.decision,
+                reason_codes=guardrail_result.reason_codes + ["idempotency_duplicate"],
+                duration_seconds=None,
+                notes=f"skipped_duplicate_idempotency_key:{key}",
             )
 
         attempt_no = 1
@@ -175,23 +241,18 @@ class HardwareExecutor:
             retry_no = attempt_no
             backoff_seconds = self._retry_policy.backoff_seconds_for_retry(retry_no)
             retry_at = dispatch_time + timedelta(seconds=backoff_seconds)
-            self._pending_runtime_events.append(
-                ExecutorEventV1(
-                    schema_version="executor_event_v1",
-                    timestamp=dispatch_time,
-                    status=ExecutorStatus.SKIPPED,
-                    action_type=str(effective_action.action_type),
-                    guardrail_decision=guardrail_result.decision,
-                    reason_codes=guardrail_result.reason_codes,
-                    duration_seconds=None,
-                    notes=(
-                        "retry_scheduled:"
-                        f"adapter={dispatch_result.adapter_name}:"
-                        f"attempt={retry_no + 1}:"
-                        f"backoff_seconds={backoff_seconds:.3f}:"
-                        f"execute_at={retry_at.isoformat()}"
-                    ),
-                )
+            self._append_runtime_event(
+                timestamp=dispatch_time,
+                action_type=str(effective_action.action_type),
+                guardrail_decision=guardrail_result.decision,
+                reason_codes=guardrail_result.reason_codes,
+                note=(
+                    "retry_scheduled:"
+                    f"adapter={dispatch_result.adapter_name}:"
+                    f"attempt={retry_no + 1}:"
+                    f"backoff_seconds={backoff_seconds:.3f}:"
+                    f"execute_at={retry_at.isoformat()}"
+                ),
             )
 
             attempt_no += 1
@@ -200,23 +261,43 @@ class HardwareExecutor:
 
         clipped = guardrail_result.decision == GuardrailDecision.CLIPPED.value
         if clipped:
-            if attempt_no > 1:
-                note = (
-                    "executed_after_retry_"
-                    f"{dispatch_result.adapter_name}_clipped:"
-                    f"{dispatch_result.command}:attempts={attempt_no}"
-                )
-            else:
-                note = f"executed_{dispatch_result.adapter_name}_clipped:{dispatch_result.command}"
+            note = (
+                "executed_after_retry_"
+                f"{dispatch_result.adapter_name}_clipped:"
+                f"{dispatch_result.command}:attempts={attempt_no}"
+                if attempt_no > 1
+                else f"executed_{dispatch_result.adapter_name}_clipped:{dispatch_result.command}"
+            )
         else:
-            if attempt_no > 1:
-                note = (
-                    "executed_after_retry_"
-                    f"{dispatch_result.adapter_name}:"
-                    f"{dispatch_result.command}:attempts={attempt_no}"
+            note = (
+                "executed_after_retry_"
+                f"{dispatch_result.adapter_name}:"
+                f"{dispatch_result.command}:attempts={attempt_no}"
+                if attempt_no > 1
+                else f"executed_{dispatch_result.adapter_name}:{dispatch_result.command}"
+            )
+
+        if key is not None:
+            if len(self._idempotency_cache) >= self._idempotency.max_entries:
+                oldest_key = min(
+                    self._idempotency_cache,
+                    key=lambda k: self._idempotency_cache[k].first_seen_at,
                 )
-            else:
-                note = f"executed_{dispatch_result.adapter_name}:{dispatch_result.command}"
+                self._idempotency_cache.pop(oldest_key, None)
+            expires_at = dispatch_time + timedelta(seconds=self._idempotency.ttl_seconds)
+            self._idempotency_cache[key] = _IdempotencyEntry(
+                key=key,
+                first_seen_at=dispatch_time,
+                expires_at=expires_at,
+            )
+            self._append_runtime_event(
+                timestamp=dispatch_time,
+                action_type=str(effective_action.action_type),
+                guardrail_decision=guardrail_result.decision,
+                reason_codes=guardrail_result.reason_codes,
+                note=f"idempotency_stored:key={key}:expires_at={expires_at.isoformat()}",
+            )
+
         return ExecutorEventV1(
             schema_version="executor_event_v1",
             timestamp=dispatch_time,

--- a/brain/executor/idempotency.py
+++ b/brain/executor/idempotency.py
@@ -1,0 +1,19 @@
+"""Deterministic idempotency cache config for execution deduplication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IdempotencyConfig:
+    """Configuration for in-memory idempotency-key retention."""
+
+    ttl_seconds: int = 6 * 60 * 60
+    max_entries: int = 4096
+
+    def __post_init__(self) -> None:
+        if self.ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be > 0")
+        if self.max_entries <= 0:
+            raise ValueError("max_entries must be > 0")

--- a/tests/contracts/test_action_v1.py
+++ b/tests/contracts/test_action_v1.py
@@ -38,6 +38,16 @@ class TestActionV1Valid:
             )
             assert action.action_type == action_type.value
 
+    def test_idempotency_key_is_accepted_when_present(self):
+        action = ActionV1(
+            schema_version="action_v1",
+            timestamp=datetime.now(timezone.utc),
+            action_type=ActionType.WATER,
+            reason="Test action",
+            idempotency_key="idem-key-1234",
+        )
+        assert action.idempotency_key == "idem-key-1234"
+
 
 class TestActionV1Invalid:
     """Test invalid ActionV1 payloads."""
@@ -80,6 +90,16 @@ class TestActionV1Invalid:
                 timestamp=datetime.now(timezone.utc),
                 action_type=ActionType.WATER,
                 reason="Test",
+            )
+
+    def test_idempotency_key_too_short_fails(self):
+        with pytest.raises(ValidationError):
+            ActionV1(
+                schema_version="action_v1",
+                timestamp=datetime.now(timezone.utc),
+                action_type=ActionType.WATER,
+                reason="Test",
+                idempotency_key="short",
             )
 
 

--- a/tests/executor/test_idempotency.py
+++ b/tests/executor/test_idempotency.py
@@ -1,0 +1,154 @@
+"""Tests for executor idempotency-key deduplication behavior."""
+
+from datetime import datetime, timedelta, timezone
+
+from brain.contracts import ActionV1, DeviceStatusV1, GuardrailResultV1
+from brain.contracts.action_v1 import ActionType
+from brain.contracts.guardrail_result_v1 import GuardrailDecision
+from brain.executor import HardwareDispatchResult, HardwareExecutor, IdempotencyConfig
+
+
+class _CountingAdapter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    @property
+    def adapter_name(self) -> str:
+        return "counting"
+
+    def dispatch(self, *, action: ActionV1, now: datetime) -> HardwareDispatchResult:
+        self.calls += 1
+        return HardwareDispatchResult(
+            accepted=True,
+            command="COUNTED",
+            duration_seconds=action.duration_seconds,
+            adapter_name=self.adapter_name,
+        )
+
+
+def _guardrail(now: datetime) -> GuardrailResultV1:
+    return GuardrailResultV1(
+        schema_version="guardrail_result_v1",
+        timestamp=now,
+        decision=GuardrailDecision.APPROVED,
+        reason_codes=[],
+    )
+
+
+def _device_status(now: datetime) -> DeviceStatusV1:
+    return DeviceStatusV1(
+        schema_version="device_status_v1",
+        timestamp=now,
+        light_on=False,
+        fans_on=True,
+        heater_on=False,
+        pump_on=False,
+        co2_on=False,
+        mcu_connected=True,
+        mcu_uptime_seconds=100,
+        mcu_reset_count=0,
+    )
+
+
+def _action(now: datetime, *, key: str | None) -> ActionV1:
+    return ActionV1(
+        schema_version="action_v1",
+        timestamp=now,
+        action_type=ActionType.WATER,
+        duration_seconds=5.0,
+        intensity=0.7,
+        reason="idempotency-test",
+        idempotency_key=key,
+    )
+
+
+def test_duplicate_key_is_skipped_without_redispatch():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    adapter = _CountingAdapter()
+    executor = HardwareExecutor(adapter, idempotency=IdempotencyConfig(ttl_seconds=3600))
+    action = _action(now, key="idem-key-0001")
+    guardrail = _guardrail(now)
+    device_status = _device_status(now)
+
+    first = executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=now,
+        device_status=device_status,
+    )
+    _ = executor.drain_runtime_events()
+    second = executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=now + timedelta(minutes=1),
+        device_status=_device_status(now + timedelta(minutes=1)),
+    )
+    runtime_events = executor.drain_runtime_events()
+
+    assert first.status == "executed"
+    assert second.status == "skipped"
+    assert second.notes == "skipped_duplicate_idempotency_key:idem-key-0001"
+    assert "idempotency_duplicate" in second.reason_codes
+    assert adapter.calls == 1
+    assert any(
+        (e.notes or "").startswith("idempotency_hit:key=idem-key-0001")
+        for e in runtime_events
+    )
+
+
+def test_expired_key_allows_new_dispatch():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    adapter = _CountingAdapter()
+    executor = HardwareExecutor(adapter, idempotency=IdempotencyConfig(ttl_seconds=60))
+    action = _action(now, key="idem-key-0002")
+    guardrail = _guardrail(now)
+
+    executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=now,
+        device_status=_device_status(now),
+    )
+    executor.drain_runtime_events()
+
+    late_time = now + timedelta(minutes=2)
+    second = executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=late_time,
+        device_status=_device_status(late_time),
+    )
+
+    assert second.status == "executed"
+    assert adapter.calls == 2
+
+
+def test_missing_key_keeps_backward_compatible_behavior():
+    now = datetime(2026, 2, 15, 0, 0, tzinfo=timezone.utc)
+    adapter = _CountingAdapter()
+    executor = HardwareExecutor(adapter)
+    action = _action(now, key=None)
+    guardrail = _guardrail(now)
+
+    first = executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=now,
+        device_status=_device_status(now),
+    )
+    second = executor.execute(
+        proposed_action=action,
+        effective_action=action,
+        guardrail_result=guardrail,
+        now=now + timedelta(minutes=1),
+        device_status=_device_status(now + timedelta(minutes=1)),
+    )
+
+    assert first.status == "executed"
+    assert second.status == "executed"
+    assert adapter.calls == 2


### PR DESCRIPTION
## Summary
- add idempotency_key to ActionV1 for execution deduplication requests
- add deterministic idempotency cache config (IdempotencyConfig) with TTL and bounded retention
- integrate idempotency dedup checks into HardwareExecutor before dispatch
- skip duplicate requests with clear reason code (idempotency_duplicate) and note metadata
- persist idempotency tracking events (idempotency_stored, idempotency_hit) in executor_log.jsonl runtime events
- keep backward compatibility when no idempotency key is provided
- update Stage 5 runtime docs in README/AGENTS/PLANNED_FEATURES

## Testing
- pytest -q --no-cov tests/contracts/test_action_v1.py tests/executor/test_idempotency.py tests/executor/test_hardware_executor.py tests/integration/test_24h_deterministic_run.py
- result: 30 passed

Closes #73